### PR TITLE
Add /integrations/ folder with 54 declarative integration capabilities

### DIFF
--- a/integrations-source.yml
+++ b/integrations-source.yml
@@ -1,0 +1,742 @@
+# Curated top-50 Stripe integrations grouped by category.
+# Each entry becomes one Naftiko capability YAML in integrations/.
+# Categories reflect Stripe's actual app marketplace + commonly-paired tooling.
+
+# CRM / Sales (6)
+- partner: salesforce
+  name: Sync Stripe customers into Salesforce contacts
+  category: CRM
+  use_case: When a Stripe customer is created, create or update the matching Salesforce Contact (by email) with billing details and lifetime spend.
+  partner_baseUri: https://yourinstance.my.salesforce.com
+  partner_api: Salesforce REST API
+  stripe_ops:
+    - getCustomers
+    - getCustomer
+  partner_ops:
+    - method: POST
+      path: /services/data/v60.0/sobjects/Contact
+      name: createContact
+    - method: PATCH
+      path: /services/data/v60.0/sobjects/Contact/{id}
+      name: updateContact
+
+- partner: hubspot
+  name: Push Stripe successful charges as HubSpot deals
+  category: CRM
+  use_case: When a Stripe charge succeeds, create or update a HubSpot Deal in the Closed Won stage attached to the matching Contact.
+  partner_baseUri: https://api.hubapi.com
+  partner_api: HubSpot CRM API
+  stripe_ops:
+    - getCharges
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /crm/v3/objects/deals
+      name: createDeal
+    - method: GET
+      path: /crm/v3/objects/contacts/{contactId}
+      name: getContact
+
+- partner: pipedrive
+  name: Mirror Stripe subscription lifecycle into Pipedrive deals
+  category: CRM
+  use_case: Forward Stripe subscription created / updated / canceled events as Pipedrive Deal stage changes.
+  partner_baseUri: https://api.pipedrive.com
+  partner_api: Pipedrive API
+  stripe_ops:
+    - getSubscriptions
+    - getSubscription
+  partner_ops:
+    - method: POST
+      path: /v1/deals
+      name: createDeal
+    - method: PUT
+      path: /v1/deals/{id}
+      name: updateDeal
+
+- partner: close
+  name: Sync Stripe payments to Close opportunities
+  category: CRM
+  use_case: Map Stripe successful payments to Close Opportunities by customer email; create activity log entries.
+  partner_baseUri: https://api.close.com
+  partner_api: Close API
+  stripe_ops:
+    - getPaymentIntents
+  partner_ops:
+    - method: POST
+      path: /api/v1/opportunity/
+      name: createOpportunity
+
+- partner: zoho-crm
+  name: Sync Stripe customer billing into Zoho CRM accounts
+  category: CRM
+  use_case: Push Stripe Customer billing details into matching Zoho CRM Accounts with custom MRR field.
+  partner_baseUri: https://www.zohoapis.com
+  partner_api: Zoho CRM REST API
+  stripe_ops:
+    - getCustomer
+    - getInvoices
+  partner_ops:
+    - method: POST
+      path: /crm/v5/Accounts
+      name: upsertAccount
+
+- partner: outreach
+  name: Mark Outreach prospects who converted in Stripe
+  category: Sales engagement
+  use_case: When a Stripe Customer first converts to paid, tag the matching Outreach Prospect as Converted and pause active sequences.
+  partner_baseUri: https://api.outreach.io
+  partner_api: Outreach API
+  stripe_ops:
+    - getCustomer
+  partner_ops:
+    - method: PATCH
+      path: /api/v2/prospects/{id}
+      name: updateProspect
+
+# Email / marketing automation (6)
+- partner: mailchimp
+  name: Add Stripe Checkout completers to a Mailchimp audience
+  category: Email marketing
+  use_case: When a Stripe Checkout session completes, add the customer to a Mailchimp audience with merge tags for plan and MRR.
+  partner_baseUri: https://us1.api.mailchimp.com
+  partner_api: Mailchimp Marketing API
+  stripe_ops:
+    - getCheckoutSession
+  partner_ops:
+    - method: POST
+      path: /3.0/lists/{list_id}/members
+      name: addAudienceMember
+
+- partner: klaviyo
+  name: Forward Stripe payment events to Klaviyo as profile events
+  category: Email marketing
+  use_case: Forward Stripe payment.intent.succeeded / customer.subscription.created webhooks to Klaviyo as profile-level events.
+  partner_baseUri: https://a.klaviyo.com
+  partner_api: Klaviyo API
+  stripe_ops:
+    - getPaymentIntents
+    - getCustomer
+  partner_ops:
+    - method: POST
+      path: /api/events/
+      name: trackEvent
+
+- partner: sendgrid
+  name: Trigger SendGrid transactional template on Stripe payment success
+  category: Transactional email
+  use_case: When a Stripe payment succeeds, render and send a SendGrid Dynamic Template (receipt) to the customer email.
+  partner_baseUri: https://api.sendgrid.com
+  partner_api: SendGrid v3 API
+  stripe_ops:
+    - getPaymentIntent
+  partner_ops:
+    - method: POST
+      path: /v3/mail/send
+      name: sendDynamicTemplate
+
+- partner: customer-io
+  name: Forward Stripe subscription lifecycle to Customer.io events
+  category: Email marketing
+  use_case: Forward Stripe subscription lifecycle webhooks (created/updated/canceled/paused) to Customer.io as user-level events.
+  partner_baseUri: https://track.customer.io
+  partner_api: Customer.io Track API
+  stripe_ops:
+    - getSubscription
+  partner_ops:
+    - method: POST
+      path: /api/v1/customers/{customer_id}/events
+      name: trackEvent
+
+- partner: iterable
+  name: Sync Stripe trial-end events to Iterable
+  category: Email marketing
+  use_case: Forward Stripe customer.subscription.trial_will_end events to Iterable as user events to trigger conversion campaigns.
+  partner_baseUri: https://api.iterable.com
+  partner_api: Iterable API
+  stripe_ops:
+    - getSubscription
+  partner_ops:
+    - method: POST
+      path: /api/events/track
+      name: trackEvent
+
+- partner: braze
+  name: Forward Stripe events to Braze custom events
+  category: Email marketing
+  use_case: Map Stripe events into Braze custom user events with the customer attached by email or external_id.
+  partner_baseUri: https://rest.iad-01.braze.com
+  partner_api: Braze REST API
+  stripe_ops:
+    - getCustomer
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /users/track
+      name: trackEvent
+
+# Subscription / billing tools (5)
+- partner: chargebee
+  name: Bridge Chargebee subscriptions to Stripe payment methods
+  category: Subscription billing
+  use_case: Use Chargebee for subscription state of record while Stripe handles payment method storage and charge collection.
+  partner_baseUri: https://yoursite.chargebee.com
+  partner_api: Chargebee API v2
+  stripe_ops:
+    - getPaymentMethod
+  partner_ops:
+    - method: POST
+      path: /api/v2/subscriptions
+      name: createSubscription
+
+- partner: recurly
+  name: Mirror Recurly subscriptions in Stripe for revenue reporting
+  category: Subscription billing
+  use_case: Materialize Recurly subscriptions in Stripe as parallel Subscription objects so Stripe's reporting can be source-of-truth.
+  partner_baseUri: https://v3.recurly.com
+  partner_api: Recurly REST API
+  stripe_ops:
+    - postSubscription
+  partner_ops:
+    - method: GET
+      path: /subscriptions
+      name: listSubscriptions
+
+- partner: zuora
+  name: Reconcile Zuora invoices against Stripe payments
+  category: Subscription billing
+  use_case: For each Zuora invoice, find and link the corresponding Stripe PaymentIntent and record the reconciliation status.
+  partner_baseUri: https://rest.zuora.com
+  partner_api: Zuora REST API
+  stripe_ops:
+    - getPaymentIntents
+  partner_ops:
+    - method: GET
+      path: /v1/invoices
+      name: listInvoices
+
+- partner: maxio
+  name: Sync Maxio (Chargify) usage events into Stripe metered subscriptions
+  category: Subscription billing
+  use_case: Push Maxio metered usage events into Stripe metered subscription items so billing rolls up in Stripe.
+  partner_baseUri: https://subdomain.chargify.com
+  partner_api: Maxio API
+  stripe_ops:
+    - postSubscriptionItemUsage
+  partner_ops:
+    - method: GET
+      path: /event_based_billing/components/{component_id}/usage_events
+      name: listUsageEvents
+
+- partner: stigg
+  name: Enforce Stigg entitlements at Stripe checkout
+  category: Pricing / packaging
+  use_case: Check Stigg entitlement before allowing a Stripe Checkout session to start (block over-quota purchases at point-of-sale).
+  partner_baseUri: https://api.stigg.io
+  partner_api: Stigg API
+  stripe_ops:
+    - postCheckoutSession
+  partner_ops:
+    - method: GET
+      path: /api/v1/entitlements/customer/{customerId}
+      name: getEntitlements
+
+# Accounting / ERP (6)
+- partner: quickbooks
+  name: Sync Stripe payouts into QuickBooks Online deposits
+  category: Accounting
+  use_case: For each Stripe payout, create a matching deposit in QuickBooks Online with per-charge line items split by fee.
+  partner_baseUri: https://quickbooks.api.intuit.com
+  partner_api: QuickBooks Online API
+  stripe_ops:
+    - getPayout
+    - getBalanceTransactions
+  partner_ops:
+    - method: POST
+      path: /v3/company/{realmId}/deposit
+      name: createDeposit
+
+- partner: xero
+  name: Reconcile Stripe payouts in Xero bank transactions
+  category: Accounting
+  use_case: Match Stripe payouts to Xero bank transactions and create per-transaction reconciliation entries.
+  partner_baseUri: https://api.xero.com
+  partner_api: Xero API
+  stripe_ops:
+    - getPayouts
+    - getBalanceTransactions
+  partner_ops:
+    - method: PUT
+      path: /api.xro/2.0/BankTransactions
+      name: createBankTransaction
+
+- partner: netsuite
+  name: Sync Stripe customer + invoice to NetSuite ERP
+  category: ERP
+  use_case: Mirror Stripe Customer + Invoice as NetSuite Customer + Invoice records via the SuiteTalk REST API.
+  partner_baseUri: https://yourcompany.suitetalk.api.netsuite.com
+  partner_api: NetSuite SuiteTalk REST
+  stripe_ops:
+    - getInvoice
+    - getCustomer
+  partner_ops:
+    - method: POST
+      path: /services/rest/record/v1/invoice
+      name: createInvoice
+
+- partner: sage-intacct
+  name: Post Stripe revenue into Sage Intacct GL
+  category: Accounting
+  use_case: For each Stripe Invoice paid, write a corresponding journal entry into Sage Intacct's general ledger.
+  partner_baseUri: https://api.intacct.com
+  partner_api: Sage Intacct API
+  stripe_ops:
+    - getInvoice
+  partner_ops:
+    - method: POST
+      path: /ia/xml/xmlgw.phtml
+      name: createJournalEntry
+
+- partner: freshbooks
+  name: Generate FreshBooks invoices from Stripe Checkout sessions
+  category: Accounting
+  use_case: When a Stripe Checkout completes for an invoice product, mark the matching FreshBooks invoice as paid.
+  partner_baseUri: https://api.freshbooks.com
+  partner_api: FreshBooks API
+  stripe_ops:
+    - getCheckoutSession
+  partner_ops:
+    - method: PUT
+      path: /accounting/account/{account_id}/invoices/invoices/{invoice_id}
+      name: updateInvoice
+
+- partner: wave
+  name: Mirror Stripe sales into Wave accounting
+  category: Accounting
+  use_case: Sync Stripe payment events into Wave as income transactions in the right account category.
+  partner_baseUri: https://gql.waveapps.com
+  partner_api: Wave Accounting GraphQL
+  stripe_ops:
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /graphql/public
+      name: createMoneyTransaction
+
+# Tax (4)
+- partner: avalara
+  name: Calculate Avalara tax at Stripe Checkout
+  category: Tax
+  use_case: Call Avalara AvaTax to compute the correct tax line for a cart, then attach to the Stripe Checkout Session.
+  partner_baseUri: https://rest.avatax.com
+  partner_api: AvaTax REST API
+  stripe_ops:
+    - postCheckoutSession
+  partner_ops:
+    - method: POST
+      path: /api/v2/transactions/create
+      name: createTransaction
+
+- partner: taxjar
+  name: File Stripe sales through TaxJar
+  category: Tax
+  use_case: Sync Stripe Invoices to TaxJar as transactions for automated state filing.
+  partner_baseUri: https://api.taxjar.com
+  partner_api: TaxJar SmartCalcs API
+  stripe_ops:
+    - getInvoices
+  partner_ops:
+    - method: POST
+      path: /v2/transactions/orders
+      name: createOrderTransaction
+
+- partner: vertex
+  name: Replace Stripe Tax with Vertex for enterprise tax determination
+  category: Tax
+  use_case: Use Vertex for tax determination, then attach the Vertex-computed line to the Stripe payment.
+  partner_baseUri: https://api.vertexsmb.com
+  partner_api: Vertex Cloud API
+  stripe_ops:
+    - postPaymentIntent
+  partner_ops:
+    - method: POST
+      path: /vertex-restapi/v1/sale
+      name: computeSaleTax
+
+- partner: anrok
+  name: Post Stripe SaaS subscriptions to Anrok for sales-tax compliance
+  category: Tax
+  use_case: For each Stripe Subscription billing event, mirror the transaction in Anrok for sales-tax exposure tracking.
+  partner_baseUri: https://api.anrok.com
+  partner_api: Anrok API
+  stripe_ops:
+    - getInvoice
+  partner_ops:
+    - method: POST
+      path: /v1/seller/transactions/createOrUpdate
+      name: createOrUpdateTransaction
+
+# Identity / auth (4)
+- partner: auth0
+  name: Provision Auth0 users from Stripe Customers
+  category: Identity
+  use_case: When a Stripe customer is created (via a paid signup), provision the matching Auth0 user with email_verified inherited from Stripe.
+  partner_baseUri: https://yourdomain.auth0.com
+  partner_api: Auth0 Management API
+  stripe_ops:
+    - getCustomer
+  partner_ops:
+    - method: POST
+      path: /api/v2/users
+      name: createUser
+
+- partner: okta
+  name: Sync Stripe subscription tier to Okta group membership
+  category: Identity
+  use_case: Map Stripe subscription plans to Okta Groups and update group membership when subscription tier changes.
+  partner_baseUri: https://yourdomain.okta.com
+  partner_api: Okta API
+  stripe_ops:
+    - getSubscription
+  partner_ops:
+    - method: PUT
+      path: /api/v1/groups/{groupId}/users/{userId}
+      name: addUserToGroup
+
+- partner: workos
+  name: Provision WorkOS organizations from Stripe Enterprise subscriptions
+  category: Identity / SSO
+  use_case: For Enterprise-tier Stripe subscriptions, create the corresponding WorkOS Organization with SSO configured.
+  partner_baseUri: https://api.workos.com
+  partner_api: WorkOS API
+  stripe_ops:
+    - getSubscription
+  partner_ops:
+    - method: POST
+      path: /organizations
+      name: createOrganization
+
+- partner: clerk
+  name: Bind Clerk Users to Stripe Customers
+  category: Identity
+  use_case: When a Clerk user signs up, create the matching Stripe Customer and store the customer ID on the Clerk user metadata.
+  partner_baseUri: https://api.clerk.com
+  partner_api: Clerk API
+  stripe_ops:
+    - postCustomer
+  partner_ops:
+    - method: PATCH
+      path: /v1/users/{user_id}/metadata
+      name: updateUserMetadata
+
+# Analytics / data warehouse (5)
+- partner: segment
+  name: Forward Stripe webhook events to Segment
+  category: Analytics
+  use_case: Stream all Stripe webhook events to Segment as track() / identify() / group() events keyed by customer.
+  partner_baseUri: https://api.segment.io
+  partner_api: Segment HTTP API
+  stripe_ops:
+    - getCharges
+  partner_ops:
+    - method: POST
+      path: /v1/track
+      name: trackEvent
+
+- partner: mixpanel
+  name: Track Stripe payment events in Mixpanel
+  category: Analytics
+  use_case: Forward Stripe charge / subscription events to Mixpanel as user-level events with revenue and plan props.
+  partner_baseUri: https://api.mixpanel.com
+  partner_api: Mixpanel HTTP API
+  stripe_ops:
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /track
+      name: trackEvent
+
+- partner: amplitude
+  name: Send Stripe revenue events to Amplitude
+  category: Analytics
+  use_case: For each Stripe charge succeeded event, send a corresponding revenue event to Amplitude.
+  partner_baseUri: https://api2.amplitude.com
+  partner_api: Amplitude HTTP API v2
+  stripe_ops:
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /2/httpapi
+      name: trackRevenue
+
+- partner: snowflake
+  name: Stream Stripe events into Snowflake
+  category: Data warehouse
+  use_case: Pipe Stripe webhook events into a Snowflake table via the Snowpipe REST API for downstream BI.
+  partner_baseUri: https://account.snowflakecomputing.com
+  partner_api: Snowflake Snowpipe REST API
+  stripe_ops:
+    - getEvents
+  partner_ops:
+    - method: POST
+      path: /v1/data/pipes/{pipe}/insertFiles
+      name: insertFiles
+
+- partner: looker
+  name: Power Looker dashboards from Stripe revenue data
+  category: BI
+  use_case: Expose a derived Stripe revenue view via the Looker API for embedded dashboards.
+  partner_baseUri: https://yourcompany.cloud.looker.com
+  partner_api: Looker API
+  stripe_ops:
+    - getCharges
+    - getInvoices
+  partner_ops:
+    - method: POST
+      path: /api/4.0/queries/run
+      name: runQuery
+
+# Customer support (4)
+- partner: zendesk
+  name: Attach Stripe customer history to Zendesk tickets
+  category: Support
+  use_case: When a Zendesk ticket opens, fetch the requester's Stripe Customer + recent charges and render them in a Zendesk app.
+  partner_baseUri: https://yoursubdomain.zendesk.com
+  partner_api: Zendesk API
+  stripe_ops:
+    - getCustomer
+    - getCharges
+  partner_ops:
+    - method: POST
+      path: /api/v2/tickets
+      name: createTicket
+
+- partner: intercom
+  name: Surface Stripe MRR + plan inside Intercom Inbox
+  category: Support
+  use_case: Push Stripe MRR + current plan + churn risk to Intercom as a custom attribute on the matching Contact.
+  partner_baseUri: https://api.intercom.io
+  partner_api: Intercom API
+  stripe_ops:
+    - getSubscription
+  partner_ops:
+    - method: PUT
+      path: /contacts/{id}
+      name: updateContact
+
+- partner: front
+  name: Tag Front conversations with Stripe spending tier
+  category: Support
+  use_case: When a Front conversation arrives, look up the contact's Stripe LTV and apply a tier tag (VIP / standard / churned).
+  partner_baseUri: https://api2.frontapp.com
+  partner_api: Front API
+  stripe_ops:
+    - getCustomer
+    - getCharges
+  partner_ops:
+    - method: POST
+      path: /conversations/{conversation_id}/tags
+      name: tagConversation
+
+- partner: gorgias
+  name: Show Stripe order context in Gorgias for e-commerce support
+  category: Support
+  use_case: When a Gorgias ticket opens, fetch the customer's Stripe Checkout sessions to show order context inline.
+  partner_baseUri: https://yourdomain.gorgias.com
+  partner_api: Gorgias REST API
+  stripe_ops:
+    - getCheckoutSessions
+  partner_ops:
+    - method: GET
+      path: /api/customers
+      name: getCustomers
+
+# E-commerce platforms (4)
+- partner: shopify
+  name: Use Stripe for Shopify checkout outside Shopify Payments
+  category: E-commerce
+  use_case: Process Shopify checkouts via Stripe (where Shopify Payments isn't available) by attaching Stripe PaymentIntents to Shopify Draft Orders.
+  partner_baseUri: https://yourshop.myshopify.com
+  partner_api: Shopify Admin REST API
+  stripe_ops:
+    - postPaymentIntent
+  partner_ops:
+    - method: POST
+      path: /admin/api/2024-04/orders.json
+      name: createOrder
+
+- partner: bigcommerce
+  name: Sync BigCommerce orders to Stripe payments
+  category: E-commerce
+  use_case: For each BigCommerce order, materialize the corresponding Stripe PaymentIntent so financial reporting consolidates in Stripe.
+  partner_baseUri: https://api.bigcommerce.com
+  partner_api: BigCommerce v3 API
+  stripe_ops:
+    - postPaymentIntent
+  partner_ops:
+    - method: GET
+      path: /stores/{store_hash}/v3/orders
+      name: listOrders
+
+- partner: woocommerce
+  name: Replace WooCommerce Stripe plugin with declarative integration
+  category: E-commerce
+  use_case: Move WooCommerce-to-Stripe handoff from the WP plugin to a declarative integration capability.
+  partner_baseUri: https://yourstore.com
+  partner_api: WooCommerce REST API
+  stripe_ops:
+    - postPaymentIntent
+  partner_ops:
+    - method: GET
+      path: /wp-json/wc/v3/orders
+      name: listOrders
+
+- partner: squarespace
+  name: Process Squarespace Commerce orders through Stripe
+  category: E-commerce
+  use_case: Capture Squarespace Commerce orders, route the payment through a Stripe PaymentIntent created via this capability.
+  partner_baseUri: https://api.squarespace.com
+  partner_api: Squarespace API
+  stripe_ops:
+    - postPaymentIntent
+  partner_ops:
+    - method: GET
+      path: /1.0/commerce/orders
+      name: listOrders
+
+# Workflow / automation (4)
+- partner: zapier
+  name: Stripe trigger spec for Zapier (declarative)
+  category: Workflow
+  use_case: Declare the Stripe events that trigger Zapier Zaps as a Naftiko capability — replaces the closed Zapier app config.
+  partner_baseUri: https://hooks.zapier.com
+  partner_api: Zapier Webhooks
+  stripe_ops:
+    - getEvents
+  partner_ops:
+    - method: POST
+      path: /hooks/catch/{hook_id}/{token}
+      name: invokeHook
+
+- partner: make
+  name: Stripe → Make scenario invocation
+  category: Workflow
+  use_case: Trigger a Make scenario from a Stripe event using a declarative integration capability.
+  partner_baseUri: https://hook.make.com
+  partner_api: Make Webhook
+  stripe_ops:
+    - getEvents
+  partner_ops:
+    - method: POST
+      path: /{hook_path}
+      name: invokeScenario
+
+- partner: n8n
+  name: Run n8n workflow on Stripe event
+  category: Workflow
+  use_case: Trigger an n8n workflow from a Stripe webhook through a declarative capability mapping.
+  partner_baseUri: https://yourdomain.app.n8n.cloud
+  partner_api: n8n Webhook
+  stripe_ops:
+    - getEvents
+  partner_ops:
+    - method: POST
+      path: /webhook/{path}
+      name: invokeWorkflow
+
+- partner: workato
+  name: Forward Stripe event to Workato recipe
+  category: Workflow
+  use_case: Forward a Stripe event into a Workato recipe via a declarative capability.
+  partner_baseUri: https://www.workato.com
+  partner_api: Workato API
+  stripe_ops:
+    - getEvents
+  partner_ops:
+    - method: POST
+      path: /webhooks/rest/{token}
+      name: invokeRecipe
+
+# Notifications / SMS / chat (3)
+- partner: twilio
+  name: SMS Stripe payment receipts via Twilio
+  category: Notifications
+  use_case: For each Stripe payment succeeded, send an SMS receipt via Twilio to the customer's phone number.
+  partner_baseUri: https://api.twilio.com
+  partner_api: Twilio Messaging API
+  stripe_ops:
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /2010-04-01/Accounts/{AccountSid}/Messages.json
+      name: sendSms
+
+- partner: slack
+  name: Post Stripe payment alerts to Slack channels
+  category: Notifications
+  use_case: Forward Stripe payment / dispute / payout events to a designated Slack channel via Incoming Webhook.
+  partner_baseUri: https://hooks.slack.com
+  partner_api: Slack Incoming Webhooks
+  stripe_ops:
+    - getCharge
+    - getDispute
+    - getPayout
+  partner_ops:
+    - method: POST
+      path: /services/{T}/{B}/{X}
+      name: postMessage
+
+- partner: messagebird
+  name: Multi-channel notify on Stripe events via MessageBird
+  category: Notifications
+  use_case: Send SMS / WhatsApp / Email via MessageBird Conversations on Stripe payment events with channel fallback.
+  partner_baseUri: https://conversations.messagebird.com
+  partner_api: MessageBird Conversations API
+  stripe_ops:
+    - getCharge
+  partner_ops:
+    - method: POST
+      path: /v1/conversations/start
+      name: startConversation
+
+# Fraud / risk (2)
+- partner: sift
+  name: Score Stripe payment intents with Sift fraud
+  category: Risk
+  use_case: Before confirming a Stripe PaymentIntent, send the order context to Sift Decisions and route based on the returned score.
+  partner_baseUri: https://api.sift.com
+  partner_api: Sift Decisions API
+  stripe_ops:
+    - postPaymentIntent
+  partner_ops:
+    - method: POST
+      path: /v205/events
+      name: postEvent
+
+- partner: riskified
+  name: Approve / decline Stripe charges via Riskified
+  category: Risk
+  use_case: For each Stripe authorize-only PaymentIntent, decide capture / void based on Riskified's order approval response.
+  partner_baseUri: https://api.riskified.com
+  partner_api: Riskified Decision API
+  stripe_ops:
+    - postPaymentIntentCapture
+  partner_ops:
+    - method: POST
+      path: /api/decide
+      name: postDecide
+
+# Analytics / dispute / chargeback / risk (1)
+- partner: chargehound
+  name: Auto-respond to Stripe disputes via Chargehound
+  category: Risk
+  use_case: When a Stripe dispute opens, build evidence in Chargehound and submit it back through the Stripe Disputes API.
+  partner_baseUri: https://api.chargehound.com
+  partner_api: Chargehound API
+  stripe_ops:
+    - getDispute
+    - postDispute
+  partner_ops:
+    - method: POST
+      path: /v1/disputes/{id}/submit
+      name: submitDispute

--- a/integrations/_index.yml
+++ b/integrations/_index.yml
@@ -1,0 +1,270 @@
+- slug: stripe-salesforce
+  label: Sync Stripe customers into Salesforce contacts
+  partner: salesforce
+  category: CRM
+  use_case: When a Stripe customer is created, create or update the matching Salesforce Contact (by email) with billing details and lifetime spend.
+- slug: stripe-hubspot
+  label: Push Stripe successful charges as HubSpot deals
+  partner: hubspot
+  category: CRM
+  use_case: When a Stripe charge succeeds, create or update a HubSpot Deal in the Closed Won stage attached to the matching Contact.
+- slug: stripe-pipedrive
+  label: Mirror Stripe subscription lifecycle into Pipedrive deals
+  partner: pipedrive
+  category: CRM
+  use_case: Forward Stripe subscription created / updated / canceled events as Pipedrive Deal stage changes.
+- slug: stripe-close
+  label: Sync Stripe payments to Close opportunities
+  partner: close
+  category: CRM
+  use_case: Map Stripe successful payments to Close Opportunities by customer email; create activity log entries.
+- slug: stripe-zoho-crm
+  label: Sync Stripe customer billing into Zoho CRM accounts
+  partner: zoho-crm
+  category: CRM
+  use_case: Push Stripe Customer billing details into matching Zoho CRM Accounts with custom MRR field.
+- slug: stripe-outreach
+  label: Mark Outreach prospects who converted in Stripe
+  partner: outreach
+  category: Sales engagement
+  use_case: When a Stripe Customer first converts to paid, tag the matching Outreach Prospect as Converted and pause active sequences.
+- slug: stripe-mailchimp
+  label: Add Stripe Checkout completers to a Mailchimp audience
+  partner: mailchimp
+  category: Email marketing
+  use_case: When a Stripe Checkout session completes, add the customer to a Mailchimp audience with merge tags for plan and MRR.
+- slug: stripe-klaviyo
+  label: Forward Stripe payment events to Klaviyo as profile events
+  partner: klaviyo
+  category: Email marketing
+  use_case: Forward Stripe payment.intent.succeeded / customer.subscription.created webhooks to Klaviyo as profile-level events.
+- slug: stripe-sendgrid
+  label: Trigger SendGrid transactional template on Stripe payment success
+  partner: sendgrid
+  category: Transactional email
+  use_case: When a Stripe payment succeeds, render and send a SendGrid Dynamic Template (receipt) to the customer email.
+- slug: stripe-customer-io
+  label: Forward Stripe subscription lifecycle to Customer.io events
+  partner: customer-io
+  category: Email marketing
+  use_case: Forward Stripe subscription lifecycle webhooks (created/updated/canceled/paused) to Customer.io as user-level events.
+- slug: stripe-iterable
+  label: Sync Stripe trial-end events to Iterable
+  partner: iterable
+  category: Email marketing
+  use_case: Forward Stripe customer.subscription.trial_will_end events to Iterable as user events to trigger conversion campaigns.
+- slug: stripe-braze
+  label: Forward Stripe events to Braze custom events
+  partner: braze
+  category: Email marketing
+  use_case: Map Stripe events into Braze custom user events with the customer attached by email or external_id.
+- slug: stripe-chargebee
+  label: Bridge Chargebee subscriptions to Stripe payment methods
+  partner: chargebee
+  category: Subscription billing
+  use_case: Use Chargebee for subscription state of record while Stripe handles payment method storage and charge collection.
+- slug: stripe-recurly
+  label: Mirror Recurly subscriptions in Stripe for revenue reporting
+  partner: recurly
+  category: Subscription billing
+  use_case: Materialize Recurly subscriptions in Stripe as parallel Subscription objects so Stripe's reporting can be source-of-truth.
+- slug: stripe-zuora
+  label: Reconcile Zuora invoices against Stripe payments
+  partner: zuora
+  category: Subscription billing
+  use_case: For each Zuora invoice, find and link the corresponding Stripe PaymentIntent and record the reconciliation status.
+- slug: stripe-maxio
+  label: Sync Maxio (Chargify) usage events into Stripe metered subscriptions
+  partner: maxio
+  category: Subscription billing
+  use_case: Push Maxio metered usage events into Stripe metered subscription items so billing rolls up in Stripe.
+- slug: stripe-stigg
+  label: Enforce Stigg entitlements at Stripe checkout
+  partner: stigg
+  category: Pricing / packaging
+  use_case: Check Stigg entitlement before allowing a Stripe Checkout session to start (block over-quota purchases at point-of-sale).
+- slug: stripe-quickbooks
+  label: Sync Stripe payouts into QuickBooks Online deposits
+  partner: quickbooks
+  category: Accounting
+  use_case: For each Stripe payout, create a matching deposit in QuickBooks Online with per-charge line items split by fee.
+- slug: stripe-xero
+  label: Reconcile Stripe payouts in Xero bank transactions
+  partner: xero
+  category: Accounting
+  use_case: Match Stripe payouts to Xero bank transactions and create per-transaction reconciliation entries.
+- slug: stripe-netsuite
+  label: Sync Stripe customer + invoice to NetSuite ERP
+  partner: netsuite
+  category: ERP
+  use_case: Mirror Stripe Customer + Invoice as NetSuite Customer + Invoice records via the SuiteTalk REST API.
+- slug: stripe-sage-intacct
+  label: Post Stripe revenue into Sage Intacct GL
+  partner: sage-intacct
+  category: Accounting
+  use_case: For each Stripe Invoice paid, write a corresponding journal entry into Sage Intacct's general ledger.
+- slug: stripe-freshbooks
+  label: Generate FreshBooks invoices from Stripe Checkout sessions
+  partner: freshbooks
+  category: Accounting
+  use_case: When a Stripe Checkout completes for an invoice product, mark the matching FreshBooks invoice as paid.
+- slug: stripe-wave
+  label: Mirror Stripe sales into Wave accounting
+  partner: wave
+  category: Accounting
+  use_case: Sync Stripe payment events into Wave as income transactions in the right account category.
+- slug: stripe-avalara
+  label: Calculate Avalara tax at Stripe Checkout
+  partner: avalara
+  category: Tax
+  use_case: Call Avalara AvaTax to compute the correct tax line for a cart, then attach to the Stripe Checkout Session.
+- slug: stripe-taxjar
+  label: File Stripe sales through TaxJar
+  partner: taxjar
+  category: Tax
+  use_case: Sync Stripe Invoices to TaxJar as transactions for automated state filing.
+- slug: stripe-vertex
+  label: Replace Stripe Tax with Vertex for enterprise tax determination
+  partner: vertex
+  category: Tax
+  use_case: Use Vertex for tax determination, then attach the Vertex-computed line to the Stripe payment.
+- slug: stripe-anrok
+  label: Post Stripe SaaS subscriptions to Anrok for sales-tax compliance
+  partner: anrok
+  category: Tax
+  use_case: For each Stripe Subscription billing event, mirror the transaction in Anrok for sales-tax exposure tracking.
+- slug: stripe-auth0
+  label: Provision Auth0 users from Stripe Customers
+  partner: auth0
+  category: Identity
+  use_case: When a Stripe customer is created (via a paid signup), provision the matching Auth0 user with email_verified inherited from Stripe.
+- slug: stripe-okta
+  label: Sync Stripe subscription tier to Okta group membership
+  partner: okta
+  category: Identity
+  use_case: Map Stripe subscription plans to Okta Groups and update group membership when subscription tier changes.
+- slug: stripe-workos
+  label: Provision WorkOS organizations from Stripe Enterprise subscriptions
+  partner: workos
+  category: Identity / SSO
+  use_case: For Enterprise-tier Stripe subscriptions, create the corresponding WorkOS Organization with SSO configured.
+- slug: stripe-clerk
+  label: Bind Clerk Users to Stripe Customers
+  partner: clerk
+  category: Identity
+  use_case: When a Clerk user signs up, create the matching Stripe Customer and store the customer ID on the Clerk user metadata.
+- slug: stripe-segment
+  label: Forward Stripe webhook events to Segment
+  partner: segment
+  category: Analytics
+  use_case: Stream all Stripe webhook events to Segment as track() / identify() / group() events keyed by customer.
+- slug: stripe-mixpanel
+  label: Track Stripe payment events in Mixpanel
+  partner: mixpanel
+  category: Analytics
+  use_case: Forward Stripe charge / subscription events to Mixpanel as user-level events with revenue and plan props.
+- slug: stripe-amplitude
+  label: Send Stripe revenue events to Amplitude
+  partner: amplitude
+  category: Analytics
+  use_case: For each Stripe charge succeeded event, send a corresponding revenue event to Amplitude.
+- slug: stripe-snowflake
+  label: Stream Stripe events into Snowflake
+  partner: snowflake
+  category: Data warehouse
+  use_case: Pipe Stripe webhook events into a Snowflake table via the Snowpipe REST API for downstream BI.
+- slug: stripe-looker
+  label: Power Looker dashboards from Stripe revenue data
+  partner: looker
+  category: BI
+  use_case: Expose a derived Stripe revenue view via the Looker API for embedded dashboards.
+- slug: stripe-zendesk
+  label: Attach Stripe customer history to Zendesk tickets
+  partner: zendesk
+  category: Support
+  use_case: When a Zendesk ticket opens, fetch the requester's Stripe Customer + recent charges and render them in a Zendesk app.
+- slug: stripe-intercom
+  label: Surface Stripe MRR + plan inside Intercom Inbox
+  partner: intercom
+  category: Support
+  use_case: Push Stripe MRR + current plan + churn risk to Intercom as a custom attribute on the matching Contact.
+- slug: stripe-front
+  label: Tag Front conversations with Stripe spending tier
+  partner: front
+  category: Support
+  use_case: When a Front conversation arrives, look up the contact's Stripe LTV and apply a tier tag (VIP / standard / churned).
+- slug: stripe-gorgias
+  label: Show Stripe order context in Gorgias for e-commerce support
+  partner: gorgias
+  category: Support
+  use_case: When a Gorgias ticket opens, fetch the customer's Stripe Checkout sessions to show order context inline.
+- slug: stripe-shopify
+  label: Use Stripe for Shopify checkout outside Shopify Payments
+  partner: shopify
+  category: E-commerce
+  use_case: Process Shopify checkouts via Stripe (where Shopify Payments isn't available) by attaching Stripe PaymentIntents to Shopify Draft Orders.
+- slug: stripe-bigcommerce
+  label: Sync BigCommerce orders to Stripe payments
+  partner: bigcommerce
+  category: E-commerce
+  use_case: For each BigCommerce order, materialize the corresponding Stripe PaymentIntent so financial reporting consolidates in Stripe.
+- slug: stripe-woocommerce
+  label: Replace WooCommerce Stripe plugin with declarative integration
+  partner: woocommerce
+  category: E-commerce
+  use_case: Move WooCommerce-to-Stripe handoff from the WP plugin to a declarative integration capability.
+- slug: stripe-squarespace
+  label: Process Squarespace Commerce orders through Stripe
+  partner: squarespace
+  category: E-commerce
+  use_case: Capture Squarespace Commerce orders, route the payment through a Stripe PaymentIntent created via this capability.
+- slug: stripe-zapier
+  label: Stripe trigger spec for Zapier (declarative)
+  partner: zapier
+  category: Workflow
+  use_case: Declare the Stripe events that trigger Zapier Zaps as a Naftiko capability — replaces the closed Zapier app config.
+- slug: stripe-make
+  label: Stripe → Make scenario invocation
+  partner: make
+  category: Workflow
+  use_case: Trigger a Make scenario from a Stripe event using a declarative integration capability.
+- slug: stripe-n8n
+  label: Run n8n workflow on Stripe event
+  partner: n8n
+  category: Workflow
+  use_case: Trigger an n8n workflow from a Stripe webhook through a declarative capability mapping.
+- slug: stripe-workato
+  label: Forward Stripe event to Workato recipe
+  partner: workato
+  category: Workflow
+  use_case: Forward a Stripe event into a Workato recipe via a declarative capability.
+- slug: stripe-twilio
+  label: SMS Stripe payment receipts via Twilio
+  partner: twilio
+  category: Notifications
+  use_case: For each Stripe payment succeeded, send an SMS receipt via Twilio to the customer's phone number.
+- slug: stripe-slack
+  label: Post Stripe payment alerts to Slack channels
+  partner: slack
+  category: Notifications
+  use_case: Forward Stripe payment / dispute / payout events to a designated Slack channel via Incoming Webhook.
+- slug: stripe-messagebird
+  label: Multi-channel notify on Stripe events via MessageBird
+  partner: messagebird
+  category: Notifications
+  use_case: Send SMS / WhatsApp / Email via MessageBird Conversations on Stripe payment events with channel fallback.
+- slug: stripe-sift
+  label: Score Stripe payment intents with Sift fraud
+  partner: sift
+  category: Risk
+  use_case: Before confirming a Stripe PaymentIntent, send the order context to Sift Decisions and route based on the returned score.
+- slug: stripe-riskified
+  label: Approve / decline Stripe charges via Riskified
+  partner: riskified
+  category: Risk
+  use_case: For each Stripe authorize-only PaymentIntent, decide capture / void based on Riskified's order approval response.
+- slug: stripe-chargehound
+  label: Auto-respond to Stripe disputes via Chargehound
+  partner: chargehound
+  category: Risk
+  use_case: When a Stripe dispute opens, build evidence in Chargehound and submit it back through the Stripe Disputes API.

--- a/integrations/stripe-amplitude.yaml
+++ b/integrations/stripe-amplitude.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Send Stripe revenue events to Amplitude
+  description: For each Stripe charge succeeded event, send a corresponding revenue event to Amplitude.
+  tags:
+  - Stripe
+  - Integration
+  - Analytics
+  - amplitude
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    AMPLITUDE_API_KEY: AMPLITUDE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: amplitude
+    baseUri: https://api2.amplitude.com
+    description: Amplitude HTTP API v2 operations consumed by this integration.
+    resources:
+    - name: 2-httpapi
+      path: /2/httpapi
+      operations:
+      - name: trackrevenue
+        method: POST
+        description: 'Amplitude HTTP API v2: trackRevenue'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-amplitude-mcp
+    description: MCP adapter for the stripe-amplitude integration.
+    tools:
+    - name: stripe_amplitude
+      description: Execute the stripe amplitude integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-amplitude-rest
+    port: 8080
+    description: REST adapter for the stripe-amplitude integration.
+    resources:
+    - path: /stripe-amplitude
+      name: stripe-amplitude
+      description: REST surface for the stripe-amplitude integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-amplitude integration.
+        call: stripe_amplitude
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-anrok.yaml
+++ b/integrations/stripe-anrok.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Post Stripe SaaS subscriptions to Anrok for sales-tax compliance
+  description: For each Stripe Subscription billing event, mirror the transaction in Anrok for sales-tax exposure tracking.
+  tags:
+  - Stripe
+  - Integration
+  - Tax
+  - anrok
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    ANROK_API_KEY: ANROK_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-invoices-id
+      path: /v1/invoices/{id}
+      operations:
+      - name: getinvoice
+        method: GET
+        description: Retrieve a Stripe invoice
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: anrok
+    baseUri: https://api.anrok.com
+    description: Anrok API operations consumed by this integration.
+    resources:
+    - name: v1-seller-transactions-createorupdate
+      path: /v1/seller/transactions/createOrUpdate
+      operations:
+      - name: createorupdatetransaction
+        method: POST
+        description: 'Anrok API: createOrUpdateTransaction'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-anrok-mcp
+    description: MCP adapter for the stripe-anrok integration.
+    tools:
+    - name: stripe_anrok
+      description: Execute the stripe anrok integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-anrok-rest
+    port: 8080
+    description: REST adapter for the stripe-anrok integration.
+    resources:
+    - path: /stripe-anrok
+      name: stripe-anrok
+      description: REST surface for the stripe-anrok integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-anrok integration.
+        call: stripe_anrok
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-auth0.yaml
+++ b/integrations/stripe-auth0.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Provision Auth0 users from Stripe Customers
+  description: When a Stripe customer is created (via a paid signup), provision the matching Auth0 user with email_verified inherited from Stripe.
+  tags:
+  - Stripe
+  - Integration
+  - Identity
+  - auth0
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    AUTH0_API_KEY: AUTH0_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: auth0
+    baseUri: https://yourdomain.auth0.com
+    description: Auth0 Management API operations consumed by this integration.
+    resources:
+    - name: api-v2-users
+      path: /api/v2/users
+      operations:
+      - name: createuser
+        method: POST
+        description: 'Auth0 Management API: createUser'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-auth0-mcp
+    description: MCP adapter for the stripe-auth0 integration.
+    tools:
+    - name: stripe_auth0
+      description: Execute the stripe auth0 integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-auth0-rest
+    port: 8080
+    description: REST adapter for the stripe-auth0 integration.
+    resources:
+    - path: /stripe-auth0
+      name: stripe-auth0
+      description: REST surface for the stripe-auth0 integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-auth0 integration.
+        call: stripe_auth0
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-avalara.yaml
+++ b/integrations/stripe-avalara.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Calculate Avalara tax at Stripe Checkout
+  description: Call Avalara AvaTax to compute the correct tax line for a cart, then attach to the Stripe Checkout Session.
+  tags:
+  - Stripe
+  - Integration
+  - Tax
+  - avalara
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    AVALARA_API_KEY: AVALARA_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-checkout-sessions
+      path: /v1/checkout/sessions
+      operations:
+      - name: postcheckoutsession
+        method: POST
+        description: Create a Stripe Checkout session
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: avalara
+    baseUri: https://rest.avatax.com
+    description: AvaTax REST API operations consumed by this integration.
+    resources:
+    - name: api-v2-transactions-create
+      path: /api/v2/transactions/create
+      operations:
+      - name: createtransaction
+        method: POST
+        description: 'AvaTax REST API: createTransaction'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-avalara-mcp
+    description: MCP adapter for the stripe-avalara integration.
+    tools:
+    - name: stripe_avalara
+      description: Execute the stripe avalara integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-avalara-rest
+    port: 8080
+    description: REST adapter for the stripe-avalara integration.
+    resources:
+    - path: /stripe-avalara
+      name: stripe-avalara
+      description: REST surface for the stripe-avalara integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-avalara integration.
+        call: stripe_avalara
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-bigcommerce.yaml
+++ b/integrations/stripe-bigcommerce.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync BigCommerce orders to Stripe payments
+  description: For each BigCommerce order, materialize the corresponding Stripe PaymentIntent so financial reporting consolidates in Stripe.
+  tags:
+  - Stripe
+  - Integration
+  - E-commerce
+  - bigcommerce
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    BIGCOMMERCE_API_KEY: BIGCOMMERCE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: postpaymentintent
+        method: POST
+        description: Create a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: bigcommerce
+    baseUri: https://api.bigcommerce.com
+    description: BigCommerce v3 API operations consumed by this integration.
+    resources:
+    - name: stores-store-hash-v3-orders
+      path: /stores/{store_hash}/v3/orders
+      operations:
+      - name: listorders
+        method: GET
+        description: 'BigCommerce v3 API: listOrders'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: store_hash
+          in: path
+          type: string
+          description: Path parameter store_hash.
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-bigcommerce-mcp
+    description: MCP adapter for the stripe-bigcommerce integration.
+    tools:
+    - name: stripe_bigcommerce
+      description: Execute the stripe bigcommerce integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-bigcommerce-rest
+    port: 8080
+    description: REST adapter for the stripe-bigcommerce integration.
+    resources:
+    - path: /stripe-bigcommerce
+      name: stripe-bigcommerce
+      description: REST surface for the stripe-bigcommerce integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-bigcommerce integration.
+        call: stripe_bigcommerce
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-braze.yaml
+++ b/integrations/stripe-braze.yaml
@@ -1,0 +1,112 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Forward Stripe events to Braze custom events
+  description: Map Stripe events into Braze custom user events with the customer attached by email or external_id.
+  tags:
+  - Stripe
+  - Integration
+  - Email marketing
+  - braze
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    BRAZE_API_KEY: BRAZE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: braze
+    baseUri: https://rest.iad-01.braze.com
+    description: Braze REST API operations consumed by this integration.
+    resources:
+    - name: users-track
+      path: /users/track
+      operations:
+      - name: trackevent
+        method: POST
+        description: 'Braze REST API: trackEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-braze-mcp
+    description: MCP adapter for the stripe-braze integration.
+    tools:
+    - name: stripe_braze
+      description: Execute the stripe braze integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-braze-rest
+    port: 8080
+    description: REST adapter for the stripe-braze integration.
+    resources:
+    - path: /stripe-braze
+      name: stripe-braze
+      description: REST surface for the stripe-braze integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-braze integration.
+        call: stripe_braze
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-chargebee.yaml
+++ b/integrations/stripe-chargebee.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Bridge Chargebee subscriptions to Stripe payment methods
+  description: Use Chargebee for subscription state of record while Stripe handles payment method storage and charge collection.
+  tags:
+  - Stripe
+  - Integration
+  - Subscription billing
+  - chargebee
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    CHARGEBEE_API_KEY: CHARGEBEE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-methods-id
+      path: /v1/payment_methods/{id}
+      operations:
+      - name: getpaymentmethod
+        method: GET
+        description: Retrieve a Stripe payment method
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: chargebee
+    baseUri: https://yoursite.chargebee.com
+    description: Chargebee API v2 operations consumed by this integration.
+    resources:
+    - name: api-v2-subscriptions
+      path: /api/v2/subscriptions
+      operations:
+      - name: createsubscription
+        method: POST
+        description: 'Chargebee API v2: createSubscription'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-chargebee-mcp
+    description: MCP adapter for the stripe-chargebee integration.
+    tools:
+    - name: stripe_chargebee
+      description: Execute the stripe chargebee integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-chargebee-rest
+    port: 8080
+    description: REST adapter for the stripe-chargebee integration.
+    resources:
+    - path: /stripe-chargebee
+      name: stripe-chargebee
+      description: REST surface for the stripe-chargebee integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-chargebee integration.
+        call: stripe_chargebee
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-chargehound.yaml
+++ b/integrations/stripe-chargehound.yaml
@@ -1,0 +1,122 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Auto-respond to Stripe disputes via Chargehound
+  description: When a Stripe dispute opens, build evidence in Chargehound and submit it back through the Stripe Disputes API.
+  tags:
+  - Stripe
+  - Integration
+  - Risk
+  - chargehound
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    CHARGEHOUND_API_KEY: CHARGEHOUND_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-disputes-id
+      path: /v1/disputes/{id}
+      operations:
+      - name: getdispute
+        method: GET
+        description: Retrieve a Stripe dispute
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-disputes-id
+      path: /v1/disputes/{id}
+      operations:
+      - name: postdispute
+        method: POST
+        description: Update a Stripe dispute
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: chargehound
+    baseUri: https://api.chargehound.com
+    description: Chargehound API operations consumed by this integration.
+    resources:
+    - name: v1-disputes-id-submit
+      path: /v1/disputes/{id}/submit
+      operations:
+      - name: submitdispute
+        method: POST
+        description: 'Chargehound API: submitDispute'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-chargehound-mcp
+    description: MCP adapter for the stripe-chargehound integration.
+    tools:
+    - name: stripe_chargehound
+      description: Execute the stripe chargehound integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-chargehound-rest
+    port: 8080
+    description: REST adapter for the stripe-chargehound integration.
+    resources:
+    - path: /stripe-chargehound
+      name: stripe-chargehound
+      description: REST surface for the stripe-chargehound integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-chargehound integration.
+        call: stripe_chargehound
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-clerk.yaml
+++ b/integrations/stripe-clerk.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Bind Clerk Users to Stripe Customers
+  description: When a Clerk user signs up, create the matching Stripe Customer and store the customer ID on the Clerk user metadata.
+  tags:
+  - Stripe
+  - Integration
+  - Identity
+  - clerk
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    CLERK_API_KEY: CLERK_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers
+      path: /v1/customers
+      operations:
+      - name: postcustomer
+        method: POST
+        description: Create a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: clerk
+    baseUri: https://api.clerk.com
+    description: Clerk API operations consumed by this integration.
+    resources:
+    - name: v1-users-user-id-metadata
+      path: /v1/users/{user_id}/metadata
+      operations:
+      - name: updateusermetadata
+        method: PATCH
+        description: 'Clerk API: updateUserMetadata'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: user_id
+          in: path
+          type: string
+          description: Path parameter user_id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-clerk-mcp
+    description: MCP adapter for the stripe-clerk integration.
+    tools:
+    - name: stripe_clerk
+      description: Execute the stripe clerk integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-clerk-rest
+    port: 8080
+    description: REST adapter for the stripe-clerk integration.
+    resources:
+    - path: /stripe-clerk
+      name: stripe-clerk
+      description: REST surface for the stripe-clerk integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-clerk integration.
+        call: stripe_clerk
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-close.yaml
+++ b/integrations/stripe-close.yaml
@@ -1,0 +1,90 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe payments to Close opportunities
+  description: Map Stripe successful payments to Close Opportunities by customer email; create activity log entries.
+  tags:
+  - Stripe
+  - Integration
+  - CRM
+  - close
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    CLOSE_API_KEY: CLOSE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: getpaymentintents
+        method: GET
+        description: List Stripe payment intents
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: close
+    baseUri: https://api.close.com
+    description: Close API operations consumed by this integration.
+    resources:
+    - name: api-v1-opportunity
+      path: /api/v1/opportunity/
+      operations:
+      - name: createopportunity
+        method: POST
+        description: 'Close API: createOpportunity'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-close-mcp
+    description: MCP adapter for the stripe-close integration.
+    tools:
+    - name: stripe_close
+      description: Execute the stripe close integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-close-rest
+    port: 8080
+    description: REST adapter for the stripe-close integration.
+    resources:
+    - path: /stripe-close
+      name: stripe-close
+      description: REST surface for the stripe-close integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-close integration.
+        call: stripe_close
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-customer-io.yaml
+++ b/integrations/stripe-customer-io.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Forward Stripe subscription lifecycle to Customer.io events
+  description: Forward Stripe subscription lifecycle webhooks (created/updated/canceled/paused) to Customer.io as user-level events.
+  tags:
+  - Stripe
+  - Integration
+  - Email marketing
+  - customer-io
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    CUSTOMER_IO_API_KEY: CUSTOMER_IO_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions-id
+      path: /v1/subscriptions/{id}
+      operations:
+      - name: getsubscription
+        method: GET
+        description: Retrieve a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: customer-io
+    baseUri: https://track.customer.io
+    description: Customer.io Track API operations consumed by this integration.
+    resources:
+    - name: api-v1-customers-customer-id-events
+      path: /api/v1/customers/{customer_id}/events
+      operations:
+      - name: trackevent
+        method: POST
+        description: 'Customer.io Track API: trackEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: customer_id
+          in: path
+          type: string
+          description: Path parameter customer_id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-customer-io-mcp
+    description: MCP adapter for the stripe-customer-io integration.
+    tools:
+    - name: stripe_customer_io
+      description: Execute the stripe customer io integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-customer-io-rest
+    port: 8080
+    description: REST adapter for the stripe-customer-io integration.
+    resources:
+    - path: /stripe-customer-io
+      name: stripe-customer-io
+      description: REST surface for the stripe-customer-io integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-customer-io integration.
+        call: stripe_customer_io
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-freshbooks.yaml
+++ b/integrations/stripe-freshbooks.yaml
@@ -1,0 +1,105 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Generate FreshBooks invoices from Stripe Checkout sessions
+  description: When a Stripe Checkout completes for an invoice product, mark the matching FreshBooks invoice as paid.
+  tags:
+  - Stripe
+  - Integration
+  - Accounting
+  - freshbooks
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    FRESHBOOKS_API_KEY: FRESHBOOKS_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-checkout-sessions-id
+      path: /v1/checkout/sessions/{id}
+      operations:
+      - name: getcheckoutsession
+        method: GET
+        description: Retrieve a Stripe Checkout session
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: freshbooks
+    baseUri: https://api.freshbooks.com
+    description: FreshBooks API operations consumed by this integration.
+    resources:
+    - name: accounting-account-account-id-invoices-invoices-invoice-id
+      path: /accounting/account/{account_id}/invoices/invoices/{invoice_id}
+      operations:
+      - name: updateinvoice
+        method: PUT
+        description: 'FreshBooks API: updateInvoice'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: account_id
+          in: path
+          type: string
+          description: Path parameter account_id.
+          required: true
+        - name: invoice_id
+          in: path
+          type: string
+          description: Path parameter invoice_id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-freshbooks-mcp
+    description: MCP adapter for the stripe-freshbooks integration.
+    tools:
+    - name: stripe_freshbooks
+      description: Execute the stripe freshbooks integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-freshbooks-rest
+    port: 8080
+    description: REST adapter for the stripe-freshbooks integration.
+    resources:
+    - path: /stripe-freshbooks
+      name: stripe-freshbooks
+      description: REST surface for the stripe-freshbooks integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-freshbooks integration.
+        call: stripe_freshbooks
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-front.yaml
+++ b/integrations/stripe-front.yaml
@@ -1,0 +1,112 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Tag Front conversations with Stripe spending tier
+  description: When a Front conversation arrives, look up the contact's Stripe LTV and apply a tier tag (VIP / standard / churned).
+  tags:
+  - Stripe
+  - Integration
+  - Support
+  - front
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    FRONT_API_KEY: FRONT_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-charges
+      path: /v1/charges
+      operations:
+      - name: getcharges
+        method: GET
+        description: List Stripe charges
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: front
+    baseUri: https://api2.frontapp.com
+    description: Front API operations consumed by this integration.
+    resources:
+    - name: conversations-conversation-id-tags
+      path: /conversations/{conversation_id}/tags
+      operations:
+      - name: tagconversation
+        method: POST
+        description: 'Front API: tagConversation'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: conversation_id
+          in: path
+          type: string
+          description: Path parameter conversation_id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-front-mcp
+    description: MCP adapter for the stripe-front integration.
+    tools:
+    - name: stripe_front
+      description: Execute the stripe front integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-front-rest
+    port: 8080
+    description: REST adapter for the stripe-front integration.
+    resources:
+    - path: /stripe-front
+      name: stripe-front
+      description: REST surface for the stripe-front integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-front integration.
+        call: stripe_front
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-gorgias.yaml
+++ b/integrations/stripe-gorgias.yaml
@@ -1,0 +1,85 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Show Stripe order context in Gorgias for e-commerce support
+  description: When a Gorgias ticket opens, fetch the customer's Stripe Checkout sessions to show order context inline.
+  tags:
+  - Stripe
+  - Integration
+  - Support
+  - gorgias
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    GORGIAS_API_KEY: GORGIAS_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-checkout-sessions
+      path: /v1/checkout/sessions
+      operations:
+      - name: getcheckoutsessions
+        method: GET
+        description: List Stripe Checkout sessions
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: gorgias
+    baseUri: https://yourdomain.gorgias.com
+    description: Gorgias REST API operations consumed by this integration.
+    resources:
+    - name: api-customers
+      path: /api/customers
+      operations:
+      - name: getcustomers
+        method: GET
+        description: 'Gorgias REST API: getCustomers'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  exposes:
+  - type: mcp
+    namespace: stripe-gorgias-mcp
+    description: MCP adapter for the stripe-gorgias integration.
+    tools:
+    - name: stripe_gorgias
+      description: Execute the stripe gorgias integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-gorgias-rest
+    port: 8080
+    description: REST adapter for the stripe-gorgias integration.
+    resources:
+    - path: /stripe-gorgias
+      name: stripe-gorgias
+      description: REST surface for the stripe-gorgias integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-gorgias integration.
+        call: stripe_gorgias
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-hubspot.yaml
+++ b/integrations/stripe-hubspot.yaml
@@ -1,0 +1,124 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Push Stripe successful charges as HubSpot deals
+  description: When a Stripe charge succeeds, create or update a HubSpot Deal in the Closed Won stage attached to the matching Contact.
+  tags:
+  - Stripe
+  - Integration
+  - CRM
+  - hubspot
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    HUBSPOT_API_KEY: HUBSPOT_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges
+      path: /v1/charges
+      operations:
+      - name: getcharges
+        method: GET
+        description: List Stripe charges
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: hubspot
+    baseUri: https://api.hubapi.com
+    description: HubSpot CRM API operations consumed by this integration.
+    resources:
+    - name: crm-v3-objects-deals
+      path: /crm/v3/objects/deals
+      operations:
+      - name: createdeal
+        method: POST
+        description: 'HubSpot CRM API: createDeal'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+    - name: crm-v3-objects-contacts-contactid
+      path: /crm/v3/objects/contacts/{contactId}
+      operations:
+      - name: getcontact
+        method: GET
+        description: 'HubSpot CRM API: getContact'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: contactId
+          in: path
+          type: string
+          description: Path parameter contactId.
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-hubspot-mcp
+    description: MCP adapter for the stripe-hubspot integration.
+    tools:
+    - name: stripe_hubspot
+      description: Execute the stripe hubspot integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-hubspot-rest
+    port: 8080
+    description: REST adapter for the stripe-hubspot integration.
+    resources:
+    - path: /stripe-hubspot
+      name: stripe-hubspot
+      description: REST surface for the stripe-hubspot integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-hubspot integration.
+        call: stripe_hubspot
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-intercom.yaml
+++ b/integrations/stripe-intercom.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Surface Stripe MRR + plan inside Intercom Inbox
+  description: Push Stripe MRR + current plan + churn risk to Intercom as a custom attribute on the matching Contact.
+  tags:
+  - Stripe
+  - Integration
+  - Support
+  - intercom
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    INTERCOM_API_KEY: INTERCOM_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions-id
+      path: /v1/subscriptions/{id}
+      operations:
+      - name: getsubscription
+        method: GET
+        description: Retrieve a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: intercom
+    baseUri: https://api.intercom.io
+    description: Intercom API operations consumed by this integration.
+    resources:
+    - name: contacts-id
+      path: /contacts/{id}
+      operations:
+      - name: updatecontact
+        method: PUT
+        description: 'Intercom API: updateContact'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-intercom-mcp
+    description: MCP adapter for the stripe-intercom integration.
+    tools:
+    - name: stripe_intercom
+      description: Execute the stripe intercom integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-intercom-rest
+    port: 8080
+    description: REST adapter for the stripe-intercom integration.
+    resources:
+    - path: /stripe-intercom
+      name: stripe-intercom
+      description: REST surface for the stripe-intercom integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-intercom integration.
+        call: stripe_intercom
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-iterable.yaml
+++ b/integrations/stripe-iterable.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe trial-end events to Iterable
+  description: Forward Stripe customer.subscription.trial_will_end events to Iterable as user events to trigger conversion campaigns.
+  tags:
+  - Stripe
+  - Integration
+  - Email marketing
+  - iterable
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    ITERABLE_API_KEY: ITERABLE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions-id
+      path: /v1/subscriptions/{id}
+      operations:
+      - name: getsubscription
+        method: GET
+        description: Retrieve a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: iterable
+    baseUri: https://api.iterable.com
+    description: Iterable API operations consumed by this integration.
+    resources:
+    - name: api-events-track
+      path: /api/events/track
+      operations:
+      - name: trackevent
+        method: POST
+        description: 'Iterable API: trackEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-iterable-mcp
+    description: MCP adapter for the stripe-iterable integration.
+    tools:
+    - name: stripe_iterable
+      description: Execute the stripe iterable integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-iterable-rest
+    port: 8080
+    description: REST adapter for the stripe-iterable integration.
+    resources:
+    - path: /stripe-iterable
+      name: stripe-iterable
+      description: REST surface for the stripe-iterable integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-iterable integration.
+        call: stripe_iterable
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-klaviyo.yaml
+++ b/integrations/stripe-klaviyo.yaml
@@ -1,0 +1,107 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Forward Stripe payment events to Klaviyo as profile events
+  description: Forward Stripe payment.intent.succeeded / customer.subscription.created webhooks to Klaviyo as profile-level events.
+  tags:
+  - Stripe
+  - Integration
+  - Email marketing
+  - klaviyo
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    KLAVIYO_API_KEY: KLAVIYO_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: getpaymentintents
+        method: GET
+        description: List Stripe payment intents
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: klaviyo
+    baseUri: https://a.klaviyo.com
+    description: Klaviyo API operations consumed by this integration.
+    resources:
+    - name: api-events
+      path: /api/events/
+      operations:
+      - name: trackevent
+        method: POST
+        description: 'Klaviyo API: trackEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-klaviyo-mcp
+    description: MCP adapter for the stripe-klaviyo integration.
+    tools:
+    - name: stripe_klaviyo
+      description: Execute the stripe klaviyo integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-klaviyo-rest
+    port: 8080
+    description: REST adapter for the stripe-klaviyo integration.
+    resources:
+    - path: /stripe-klaviyo
+      name: stripe-klaviyo
+      description: REST surface for the stripe-klaviyo integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-klaviyo integration.
+        call: stripe_klaviyo
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-looker.yaml
+++ b/integrations/stripe-looker.yaml
@@ -1,0 +1,102 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Power Looker dashboards from Stripe revenue data
+  description: Expose a derived Stripe revenue view via the Looker API for embedded dashboards.
+  tags:
+  - Stripe
+  - Integration
+  - BI
+  - looker
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    LOOKER_API_KEY: LOOKER_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges
+      path: /v1/charges
+      operations:
+      - name: getcharges
+        method: GET
+        description: List Stripe charges
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+    - name: v1-invoices
+      path: /v1/invoices
+      operations:
+      - name: getinvoices
+        method: GET
+        description: List Stripe invoices
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: looker
+    baseUri: https://yourcompany.cloud.looker.com
+    description: Looker API operations consumed by this integration.
+    resources:
+    - name: api-4-0-queries-run
+      path: /api/4.0/queries/run
+      operations:
+      - name: runquery
+        method: POST
+        description: 'Looker API: runQuery'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-looker-mcp
+    description: MCP adapter for the stripe-looker integration.
+    tools:
+    - name: stripe_looker
+      description: Execute the stripe looker integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-looker-rest
+    port: 8080
+    description: REST adapter for the stripe-looker integration.
+    resources:
+    - path: /stripe-looker
+      name: stripe-looker
+      description: REST surface for the stripe-looker integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-looker integration.
+        call: stripe_looker
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-mailchimp.yaml
+++ b/integrations/stripe-mailchimp.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Add Stripe Checkout completers to a Mailchimp audience
+  description: When a Stripe Checkout session completes, add the customer to a Mailchimp audience with merge tags for plan and MRR.
+  tags:
+  - Stripe
+  - Integration
+  - Email marketing
+  - mailchimp
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    MAILCHIMP_API_KEY: MAILCHIMP_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-checkout-sessions-id
+      path: /v1/checkout/sessions/{id}
+      operations:
+      - name: getcheckoutsession
+        method: GET
+        description: Retrieve a Stripe Checkout session
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: mailchimp
+    baseUri: https://us1.api.mailchimp.com
+    description: Mailchimp Marketing API operations consumed by this integration.
+    resources:
+    - name: 3-0-lists-list-id-members
+      path: /3.0/lists/{list_id}/members
+      operations:
+      - name: addaudiencemember
+        method: POST
+        description: 'Mailchimp Marketing API: addAudienceMember'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: list_id
+          in: path
+          type: string
+          description: Path parameter list_id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-mailchimp-mcp
+    description: MCP adapter for the stripe-mailchimp integration.
+    tools:
+    - name: stripe_mailchimp
+      description: Execute the stripe mailchimp integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-mailchimp-rest
+    port: 8080
+    description: REST adapter for the stripe-mailchimp integration.
+    resources:
+    - path: /stripe-mailchimp
+      name: stripe-mailchimp
+      description: REST surface for the stripe-mailchimp integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-mailchimp integration.
+        call: stripe_mailchimp
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-make.yaml
+++ b/integrations/stripe-make.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Stripe → Make scenario invocation
+  description: Trigger a Make scenario from a Stripe event using a declarative integration capability.
+  tags:
+  - Stripe
+  - Integration
+  - Workflow
+  - make
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    MAKE_API_KEY: MAKE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-events
+      path: /v1/events
+      operations:
+      - name: getevents
+        method: GET
+        description: List Stripe events
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: make
+    baseUri: https://hook.make.com
+    description: Make Webhook operations consumed by this integration.
+    resources:
+    - name: hook-path
+      path: /{hook_path}
+      operations:
+      - name: invokescenario
+        method: POST
+        description: 'Make Webhook: invokeScenario'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: hook_path
+          in: path
+          type: string
+          description: Path parameter hook_path.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-make-mcp
+    description: MCP adapter for the stripe-make integration.
+    tools:
+    - name: stripe_make
+      description: Execute the stripe make integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-make-rest
+    port: 8080
+    description: REST adapter for the stripe-make integration.
+    resources:
+    - path: /stripe-make
+      name: stripe-make
+      description: REST surface for the stripe-make integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-make integration.
+        call: stripe_make
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-maxio.yaml
+++ b/integrations/stripe-maxio.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Maxio (Chargify) usage events into Stripe metered subscriptions
+  description: Push Maxio metered usage events into Stripe metered subscription items so billing rolls up in Stripe.
+  tags:
+  - Stripe
+  - Integration
+  - Subscription billing
+  - maxio
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    MAXIO_API_KEY: MAXIO_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscription-items-id-usage-records
+      path: /v1/subscription_items/{id}/usage_records
+      operations:
+      - name: postsubscriptionitemusage
+        method: POST
+        description: Report subscription metered usage
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: maxio
+    baseUri: https://subdomain.chargify.com
+    description: Maxio API operations consumed by this integration.
+    resources:
+    - name: event-based-billing-components-component-id-usage-events
+      path: /event_based_billing/components/{component_id}/usage_events
+      operations:
+      - name: listusageevents
+        method: GET
+        description: 'Maxio API: listUsageEvents'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: component_id
+          in: path
+          type: string
+          description: Path parameter component_id.
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-maxio-mcp
+    description: MCP adapter for the stripe-maxio integration.
+    tools:
+    - name: stripe_maxio
+      description: Execute the stripe maxio integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-maxio-rest
+    port: 8080
+    description: REST adapter for the stripe-maxio integration.
+    resources:
+    - path: /stripe-maxio
+      name: stripe-maxio
+      description: REST surface for the stripe-maxio integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-maxio integration.
+        call: stripe_maxio
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-messagebird.yaml
+++ b/integrations/stripe-messagebird.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Multi-channel notify on Stripe events via MessageBird
+  description: Send SMS / WhatsApp / Email via MessageBird Conversations on Stripe payment events with channel fallback.
+  tags:
+  - Stripe
+  - Integration
+  - Notifications
+  - messagebird
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    MESSAGEBIRD_API_KEY: MESSAGEBIRD_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: messagebird
+    baseUri: https://conversations.messagebird.com
+    description: MessageBird Conversations API operations consumed by this integration.
+    resources:
+    - name: v1-conversations-start
+      path: /v1/conversations/start
+      operations:
+      - name: startconversation
+        method: POST
+        description: 'MessageBird Conversations API: startConversation'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-messagebird-mcp
+    description: MCP adapter for the stripe-messagebird integration.
+    tools:
+    - name: stripe_messagebird
+      description: Execute the stripe messagebird integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-messagebird-rest
+    port: 8080
+    description: REST adapter for the stripe-messagebird integration.
+    resources:
+    - path: /stripe-messagebird
+      name: stripe-messagebird
+      description: REST surface for the stripe-messagebird integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-messagebird integration.
+        call: stripe_messagebird
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-mixpanel.yaml
+++ b/integrations/stripe-mixpanel.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Track Stripe payment events in Mixpanel
+  description: Forward Stripe charge / subscription events to Mixpanel as user-level events with revenue and plan props.
+  tags:
+  - Stripe
+  - Integration
+  - Analytics
+  - mixpanel
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    MIXPANEL_API_KEY: MIXPANEL_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: mixpanel
+    baseUri: https://api.mixpanel.com
+    description: Mixpanel HTTP API operations consumed by this integration.
+    resources:
+    - name: track
+      path: /track
+      operations:
+      - name: trackevent
+        method: POST
+        description: 'Mixpanel HTTP API: trackEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-mixpanel-mcp
+    description: MCP adapter for the stripe-mixpanel integration.
+    tools:
+    - name: stripe_mixpanel
+      description: Execute the stripe mixpanel integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-mixpanel-rest
+    port: 8080
+    description: REST adapter for the stripe-mixpanel integration.
+    resources:
+    - path: /stripe-mixpanel
+      name: stripe-mixpanel
+      description: REST surface for the stripe-mixpanel integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-mixpanel integration.
+        call: stripe_mixpanel
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-n8n.yaml
+++ b/integrations/stripe-n8n.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Run n8n workflow on Stripe event
+  description: Trigger an n8n workflow from a Stripe webhook through a declarative capability mapping.
+  tags:
+  - Stripe
+  - Integration
+  - Workflow
+  - n8n
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    N8N_API_KEY: N8N_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-events
+      path: /v1/events
+      operations:
+      - name: getevents
+        method: GET
+        description: List Stripe events
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: n8n
+    baseUri: https://yourdomain.app.n8n.cloud
+    description: n8n Webhook operations consumed by this integration.
+    resources:
+    - name: webhook-path
+      path: /webhook/{path}
+      operations:
+      - name: invokeworkflow
+        method: POST
+        description: 'n8n Webhook: invokeWorkflow'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: path
+          in: path
+          type: string
+          description: Path parameter path.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-n8n-mcp
+    description: MCP adapter for the stripe-n8n integration.
+    tools:
+    - name: stripe_n8n
+      description: Execute the stripe n8n integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-n8n-rest
+    port: 8080
+    description: REST adapter for the stripe-n8n integration.
+    resources:
+    - path: /stripe-n8n
+      name: stripe-n8n
+      description: REST surface for the stripe-n8n integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-n8n integration.
+        call: stripe_n8n
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-netsuite.yaml
+++ b/integrations/stripe-netsuite.yaml
@@ -1,0 +1,112 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe customer + invoice to NetSuite ERP
+  description: Mirror Stripe Customer + Invoice as NetSuite Customer + Invoice records via the SuiteTalk REST API.
+  tags:
+  - Stripe
+  - Integration
+  - ERP
+  - netsuite
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    NETSUITE_API_KEY: NETSUITE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-invoices-id
+      path: /v1/invoices/{id}
+      operations:
+      - name: getinvoice
+        method: GET
+        description: Retrieve a Stripe invoice
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: netsuite
+    baseUri: https://yourcompany.suitetalk.api.netsuite.com
+    description: NetSuite SuiteTalk REST operations consumed by this integration.
+    resources:
+    - name: services-rest-record-v1-invoice
+      path: /services/rest/record/v1/invoice
+      operations:
+      - name: createinvoice
+        method: POST
+        description: 'NetSuite SuiteTalk REST: createInvoice'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-netsuite-mcp
+    description: MCP adapter for the stripe-netsuite integration.
+    tools:
+    - name: stripe_netsuite
+      description: Execute the stripe netsuite integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-netsuite-rest
+    port: 8080
+    description: REST adapter for the stripe-netsuite integration.
+    resources:
+    - path: /stripe-netsuite
+      name: stripe-netsuite
+      description: REST surface for the stripe-netsuite integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-netsuite integration.
+        call: stripe_netsuite
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-okta.yaml
+++ b/integrations/stripe-okta.yaml
@@ -1,0 +1,105 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe subscription tier to Okta group membership
+  description: Map Stripe subscription plans to Okta Groups and update group membership when subscription tier changes.
+  tags:
+  - Stripe
+  - Integration
+  - Identity
+  - okta
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    OKTA_API_KEY: OKTA_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions-id
+      path: /v1/subscriptions/{id}
+      operations:
+      - name: getsubscription
+        method: GET
+        description: Retrieve a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: okta
+    baseUri: https://yourdomain.okta.com
+    description: Okta API operations consumed by this integration.
+    resources:
+    - name: api-v1-groups-groupid-users-userid
+      path: /api/v1/groups/{groupId}/users/{userId}
+      operations:
+      - name: addusertogroup
+        method: PUT
+        description: 'Okta API: addUserToGroup'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: groupId
+          in: path
+          type: string
+          description: Path parameter groupId.
+          required: true
+        - name: userId
+          in: path
+          type: string
+          description: Path parameter userId.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-okta-mcp
+    description: MCP adapter for the stripe-okta integration.
+    tools:
+    - name: stripe_okta
+      description: Execute the stripe okta integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-okta-rest
+    port: 8080
+    description: REST adapter for the stripe-okta integration.
+    resources:
+    - path: /stripe-okta
+      name: stripe-okta
+      description: REST surface for the stripe-okta integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-okta integration.
+        call: stripe_okta
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-outreach.yaml
+++ b/integrations/stripe-outreach.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Mark Outreach prospects who converted in Stripe
+  description: When a Stripe Customer first converts to paid, tag the matching Outreach Prospect as Converted and pause active sequences.
+  tags:
+  - Stripe
+  - Integration
+  - Sales engagement
+  - outreach
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    OUTREACH_API_KEY: OUTREACH_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: outreach
+    baseUri: https://api.outreach.io
+    description: Outreach API operations consumed by this integration.
+    resources:
+    - name: api-v2-prospects-id
+      path: /api/v2/prospects/{id}
+      operations:
+      - name: updateprospect
+        method: PATCH
+        description: 'Outreach API: updateProspect'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-outreach-mcp
+    description: MCP adapter for the stripe-outreach integration.
+    tools:
+    - name: stripe_outreach
+      description: Execute the stripe outreach integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-outreach-rest
+    port: 8080
+    description: REST adapter for the stripe-outreach integration.
+    resources:
+    - path: /stripe-outreach
+      name: stripe-outreach
+      description: REST surface for the stripe-outreach integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-outreach integration.
+        call: stripe_outreach
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-pipedrive.yaml
+++ b/integrations/stripe-pipedrive.yaml
@@ -1,0 +1,129 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Mirror Stripe subscription lifecycle into Pipedrive deals
+  description: Forward Stripe subscription created / updated / canceled events as Pipedrive Deal stage changes.
+  tags:
+  - Stripe
+  - Integration
+  - CRM
+  - pipedrive
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    PIPEDRIVE_API_KEY: PIPEDRIVE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions
+      path: /v1/subscriptions
+      operations:
+      - name: getsubscriptions
+        method: GET
+        description: List Stripe subscriptions
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+    - name: v1-subscriptions-id
+      path: /v1/subscriptions/{id}
+      operations:
+      - name: getsubscription
+        method: GET
+        description: Retrieve a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: pipedrive
+    baseUri: https://api.pipedrive.com
+    description: Pipedrive API operations consumed by this integration.
+    resources:
+    - name: v1-deals
+      path: /v1/deals
+      operations:
+      - name: createdeal
+        method: POST
+        description: 'Pipedrive API: createDeal'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+    - name: v1-deals-id
+      path: /v1/deals/{id}
+      operations:
+      - name: updatedeal
+        method: PUT
+        description: 'Pipedrive API: updateDeal'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-pipedrive-mcp
+    description: MCP adapter for the stripe-pipedrive integration.
+    tools:
+    - name: stripe_pipedrive
+      description: Execute the stripe pipedrive integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-pipedrive-rest
+    port: 8080
+    description: REST adapter for the stripe-pipedrive integration.
+    resources:
+    - path: /stripe-pipedrive
+      name: stripe-pipedrive
+      description: REST surface for the stripe-pipedrive integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-pipedrive integration.
+        call: stripe_pipedrive
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-quickbooks.yaml
+++ b/integrations/stripe-quickbooks.yaml
@@ -1,0 +1,112 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe payouts into QuickBooks Online deposits
+  description: For each Stripe payout, create a matching deposit in QuickBooks Online with per-charge line items split by fee.
+  tags:
+  - Stripe
+  - Integration
+  - Accounting
+  - quickbooks
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    QUICKBOOKS_API_KEY: QUICKBOOKS_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payouts-id
+      path: /v1/payouts/{id}
+      operations:
+      - name: getpayout
+        method: GET
+        description: Retrieve a Stripe payout
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-balance-transactions
+      path: /v1/balance_transactions
+      operations:
+      - name: getbalancetransactions
+        method: GET
+        description: List Stripe balance transactions
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: quickbooks
+    baseUri: https://quickbooks.api.intuit.com
+    description: QuickBooks Online API operations consumed by this integration.
+    resources:
+    - name: v3-company-realmid-deposit
+      path: /v3/company/{realmId}/deposit
+      operations:
+      - name: createdeposit
+        method: POST
+        description: 'QuickBooks Online API: createDeposit'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: realmId
+          in: path
+          type: string
+          description: Path parameter realmId.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-quickbooks-mcp
+    description: MCP adapter for the stripe-quickbooks integration.
+    tools:
+    - name: stripe_quickbooks
+      description: Execute the stripe quickbooks integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-quickbooks-rest
+    port: 8080
+    description: REST adapter for the stripe-quickbooks integration.
+    resources:
+    - path: /stripe-quickbooks
+      name: stripe-quickbooks
+      description: REST surface for the stripe-quickbooks integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-quickbooks integration.
+        call: stripe_quickbooks
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-recurly.yaml
+++ b/integrations/stripe-recurly.yaml
@@ -1,0 +1,90 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Mirror Recurly subscriptions in Stripe for revenue reporting
+  description: Materialize Recurly subscriptions in Stripe as parallel Subscription objects so Stripe's reporting can be source-of-truth.
+  tags:
+  - Stripe
+  - Integration
+  - Subscription billing
+  - recurly
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    RECURLY_API_KEY: RECURLY_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions
+      path: /v1/subscriptions
+      operations:
+      - name: postsubscription
+        method: POST
+        description: Create a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: recurly
+    baseUri: https://v3.recurly.com
+    description: Recurly REST API operations consumed by this integration.
+    resources:
+    - name: subscriptions
+      path: /subscriptions
+      operations:
+      - name: listsubscriptions
+        method: GET
+        description: 'Recurly REST API: listSubscriptions'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  exposes:
+  - type: mcp
+    namespace: stripe-recurly-mcp
+    description: MCP adapter for the stripe-recurly integration.
+    tools:
+    - name: stripe_recurly
+      description: Execute the stripe recurly integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-recurly-rest
+    port: 8080
+    description: REST adapter for the stripe-recurly integration.
+    resources:
+    - path: /stripe-recurly
+      name: stripe-recurly
+      description: REST surface for the stripe-recurly integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-recurly integration.
+        call: stripe_recurly
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-riskified.yaml
+++ b/integrations/stripe-riskified.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Approve / decline Stripe charges via Riskified
+  description: For each Stripe authorize-only PaymentIntent, decide capture / void based on Riskified's order approval response.
+  tags:
+  - Stripe
+  - Integration
+  - Risk
+  - riskified
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    RISKIFIED_API_KEY: RISKIFIED_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents-id-capture
+      path: /v1/payment_intents/{id}/capture
+      operations:
+      - name: postpaymentintentcapture
+        method: POST
+        description: Capture a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: riskified
+    baseUri: https://api.riskified.com
+    description: Riskified Decision API operations consumed by this integration.
+    resources:
+    - name: api-decide
+      path: /api/decide
+      operations:
+      - name: postdecide
+        method: POST
+        description: 'Riskified Decision API: postDecide'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-riskified-mcp
+    description: MCP adapter for the stripe-riskified integration.
+    tools:
+    - name: stripe_riskified
+      description: Execute the stripe riskified integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-riskified-rest
+    port: 8080
+    description: REST adapter for the stripe-riskified integration.
+    resources:
+    - path: /stripe-riskified
+      name: stripe-riskified
+      description: REST surface for the stripe-riskified integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-riskified integration.
+        call: stripe_riskified
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-sage-intacct.yaml
+++ b/integrations/stripe-sage-intacct.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Post Stripe revenue into Sage Intacct GL
+  description: For each Stripe Invoice paid, write a corresponding journal entry into Sage Intacct's general ledger.
+  tags:
+  - Stripe
+  - Integration
+  - Accounting
+  - sage-intacct
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SAGE_INTACCT_API_KEY: SAGE_INTACCT_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-invoices-id
+      path: /v1/invoices/{id}
+      operations:
+      - name: getinvoice
+        method: GET
+        description: Retrieve a Stripe invoice
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: sage-intacct
+    baseUri: https://api.intacct.com
+    description: Sage Intacct API operations consumed by this integration.
+    resources:
+    - name: ia-xml-xmlgw-phtml
+      path: /ia/xml/xmlgw.phtml
+      operations:
+      - name: createjournalentry
+        method: POST
+        description: 'Sage Intacct API: createJournalEntry'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-sage-intacct-mcp
+    description: MCP adapter for the stripe-sage-intacct integration.
+    tools:
+    - name: stripe_sage_intacct
+      description: Execute the stripe sage intacct integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-sage-intacct-rest
+    port: 8080
+    description: REST adapter for the stripe-sage-intacct integration.
+    resources:
+    - path: /stripe-sage-intacct
+      name: stripe-sage-intacct
+      description: REST surface for the stripe-sage-intacct integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-sage-intacct integration.
+        call: stripe_sage_intacct
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-salesforce.yaml
+++ b/integrations/stripe-salesforce.yaml
@@ -1,0 +1,129 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe customers into Salesforce contacts
+  description: When a Stripe customer is created, create or update the matching Salesforce Contact (by email) with billing details and lifetime spend.
+  tags:
+  - Stripe
+  - Integration
+  - CRM
+  - salesforce
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SALESFORCE_API_KEY: SALESFORCE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers
+      path: /v1/customers
+      operations:
+      - name: getcustomers
+        method: GET
+        description: List Stripe customers
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: salesforce
+    baseUri: https://yourinstance.my.salesforce.com
+    description: Salesforce REST API operations consumed by this integration.
+    resources:
+    - name: services-data-v60-0-sobjects-contact
+      path: /services/data/v60.0/sobjects/Contact
+      operations:
+      - name: createcontact
+        method: POST
+        description: 'Salesforce REST API: createContact'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+    - name: services-data-v60-0-sobjects-contact-id
+      path: /services/data/v60.0/sobjects/Contact/{id}
+      operations:
+      - name: updatecontact
+        method: PATCH
+        description: 'Salesforce REST API: updateContact'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-salesforce-mcp
+    description: MCP adapter for the stripe-salesforce integration.
+    tools:
+    - name: stripe_salesforce
+      description: Execute the stripe salesforce integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-salesforce-rest
+    port: 8080
+    description: REST adapter for the stripe-salesforce integration.
+    resources:
+    - path: /stripe-salesforce
+      name: stripe-salesforce
+      description: REST surface for the stripe-salesforce integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-salesforce integration.
+        call: stripe_salesforce
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-segment.yaml
+++ b/integrations/stripe-segment.yaml
@@ -1,0 +1,90 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Forward Stripe webhook events to Segment
+  description: Stream all Stripe webhook events to Segment as track() / identify() / group() events keyed by customer.
+  tags:
+  - Stripe
+  - Integration
+  - Analytics
+  - segment
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SEGMENT_API_KEY: SEGMENT_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges
+      path: /v1/charges
+      operations:
+      - name: getcharges
+        method: GET
+        description: List Stripe charges
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: segment
+    baseUri: https://api.segment.io
+    description: Segment HTTP API operations consumed by this integration.
+    resources:
+    - name: v1-track
+      path: /v1/track
+      operations:
+      - name: trackevent
+        method: POST
+        description: 'Segment HTTP API: trackEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-segment-mcp
+    description: MCP adapter for the stripe-segment integration.
+    tools:
+    - name: stripe_segment
+      description: Execute the stripe segment integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-segment-rest
+    port: 8080
+    description: REST adapter for the stripe-segment integration.
+    resources:
+    - path: /stripe-segment
+      name: stripe-segment
+      description: REST surface for the stripe-segment integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-segment integration.
+        call: stripe_segment
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-sendgrid.yaml
+++ b/integrations/stripe-sendgrid.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Trigger SendGrid transactional template on Stripe payment success
+  description: When a Stripe payment succeeds, render and send a SendGrid Dynamic Template (receipt) to the customer email.
+  tags:
+  - Stripe
+  - Integration
+  - Transactional email
+  - sendgrid
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SENDGRID_API_KEY: SENDGRID_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents-id
+      path: /v1/payment_intents/{id}
+      operations:
+      - name: getpaymentintent
+        method: GET
+        description: Retrieve a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: sendgrid
+    baseUri: https://api.sendgrid.com
+    description: SendGrid v3 API operations consumed by this integration.
+    resources:
+    - name: v3-mail-send
+      path: /v3/mail/send
+      operations:
+      - name: senddynamictemplate
+        method: POST
+        description: 'SendGrid v3 API: sendDynamicTemplate'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-sendgrid-mcp
+    description: MCP adapter for the stripe-sendgrid integration.
+    tools:
+    - name: stripe_sendgrid
+      description: Execute the stripe sendgrid integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-sendgrid-rest
+    port: 8080
+    description: REST adapter for the stripe-sendgrid integration.
+    resources:
+    - path: /stripe-sendgrid
+      name: stripe-sendgrid
+      description: REST surface for the stripe-sendgrid integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-sendgrid integration.
+        call: stripe_sendgrid
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-shopify.yaml
+++ b/integrations/stripe-shopify.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Use Stripe for Shopify checkout outside Shopify Payments
+  description: Process Shopify checkouts via Stripe (where Shopify Payments isn't available) by attaching Stripe PaymentIntents to Shopify Draft Orders.
+  tags:
+  - Stripe
+  - Integration
+  - E-commerce
+  - shopify
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SHOPIFY_API_KEY: SHOPIFY_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: postpaymentintent
+        method: POST
+        description: Create a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: shopify
+    baseUri: https://yourshop.myshopify.com
+    description: Shopify Admin REST API operations consumed by this integration.
+    resources:
+    - name: admin-api-2024-04-orders-json
+      path: /admin/api/2024-04/orders.json
+      operations:
+      - name: createorder
+        method: POST
+        description: 'Shopify Admin REST API: createOrder'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-shopify-mcp
+    description: MCP adapter for the stripe-shopify integration.
+    tools:
+    - name: stripe_shopify
+      description: Execute the stripe shopify integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-shopify-rest
+    port: 8080
+    description: REST adapter for the stripe-shopify integration.
+    resources:
+    - path: /stripe-shopify
+      name: stripe-shopify
+      description: REST surface for the stripe-shopify integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-shopify integration.
+        call: stripe_shopify
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-sift.yaml
+++ b/integrations/stripe-sift.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Score Stripe payment intents with Sift fraud
+  description: Before confirming a Stripe PaymentIntent, send the order context to Sift Decisions and route based on the returned score.
+  tags:
+  - Stripe
+  - Integration
+  - Risk
+  - sift
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SIFT_API_KEY: SIFT_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: postpaymentintent
+        method: POST
+        description: Create a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: sift
+    baseUri: https://api.sift.com
+    description: Sift Decisions API operations consumed by this integration.
+    resources:
+    - name: v205-events
+      path: /v205/events
+      operations:
+      - name: postevent
+        method: POST
+        description: 'Sift Decisions API: postEvent'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-sift-mcp
+    description: MCP adapter for the stripe-sift integration.
+    tools:
+    - name: stripe_sift
+      description: Execute the stripe sift integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-sift-rest
+    port: 8080
+    description: REST adapter for the stripe-sift integration.
+    resources:
+    - path: /stripe-sift
+      name: stripe-sift
+      description: REST surface for the stripe-sift integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-sift integration.
+        call: stripe_sift
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-slack.yaml
+++ b/integrations/stripe-slack.yaml
@@ -1,0 +1,144 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Post Stripe payment alerts to Slack channels
+  description: Forward Stripe payment / dispute / payout events to a designated Slack channel via Incoming Webhook.
+  tags:
+  - Stripe
+  - Integration
+  - Notifications
+  - slack
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SLACK_API_KEY: SLACK_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-disputes-id
+      path: /v1/disputes/{id}
+      operations:
+      - name: getdispute
+        method: GET
+        description: Retrieve a Stripe dispute
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-payouts-id
+      path: /v1/payouts/{id}
+      operations:
+      - name: getpayout
+        method: GET
+        description: Retrieve a Stripe payout
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: slack
+    baseUri: https://hooks.slack.com
+    description: Slack Incoming Webhooks operations consumed by this integration.
+    resources:
+    - name: services-t-b-x
+      path: /services/{T}/{B}/{X}
+      operations:
+      - name: postmessage
+        method: POST
+        description: 'Slack Incoming Webhooks: postMessage'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: T
+          in: path
+          type: string
+          description: Path parameter T.
+          required: true
+        - name: B
+          in: path
+          type: string
+          description: Path parameter B.
+          required: true
+        - name: X
+          in: path
+          type: string
+          description: Path parameter X.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-slack-mcp
+    description: MCP adapter for the stripe-slack integration.
+    tools:
+    - name: stripe_slack
+      description: Execute the stripe slack integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-slack-rest
+    port: 8080
+    description: REST adapter for the stripe-slack integration.
+    resources:
+    - path: /stripe-slack
+      name: stripe-slack
+      description: REST surface for the stripe-slack integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-slack integration.
+        call: stripe_slack
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-snowflake.yaml
+++ b/integrations/stripe-snowflake.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Stream Stripe events into Snowflake
+  description: Pipe Stripe webhook events into a Snowflake table via the Snowpipe REST API for downstream BI.
+  tags:
+  - Stripe
+  - Integration
+  - Data warehouse
+  - snowflake
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SNOWFLAKE_API_KEY: SNOWFLAKE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-events
+      path: /v1/events
+      operations:
+      - name: getevents
+        method: GET
+        description: List Stripe events
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: snowflake
+    baseUri: https://account.snowflakecomputing.com
+    description: Snowflake Snowpipe REST API operations consumed by this integration.
+    resources:
+    - name: v1-data-pipes-pipe-insertfiles
+      path: /v1/data/pipes/{pipe}/insertFiles
+      operations:
+      - name: insertfiles
+        method: POST
+        description: 'Snowflake Snowpipe REST API: insertFiles'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: pipe
+          in: path
+          type: string
+          description: Path parameter pipe.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-snowflake-mcp
+    description: MCP adapter for the stripe-snowflake integration.
+    tools:
+    - name: stripe_snowflake
+      description: Execute the stripe snowflake integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-snowflake-rest
+    port: 8080
+    description: REST adapter for the stripe-snowflake integration.
+    resources:
+    - path: /stripe-snowflake
+      name: stripe-snowflake
+      description: REST surface for the stripe-snowflake integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-snowflake integration.
+        call: stripe_snowflake
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-squarespace.yaml
+++ b/integrations/stripe-squarespace.yaml
@@ -1,0 +1,90 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Process Squarespace Commerce orders through Stripe
+  description: Capture Squarespace Commerce orders, route the payment through a Stripe PaymentIntent created via this capability.
+  tags:
+  - Stripe
+  - Integration
+  - E-commerce
+  - squarespace
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    SQUARESPACE_API_KEY: SQUARESPACE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: postpaymentintent
+        method: POST
+        description: Create a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: squarespace
+    baseUri: https://api.squarespace.com
+    description: Squarespace API operations consumed by this integration.
+    resources:
+    - name: 1-0-commerce-orders
+      path: /1.0/commerce/orders
+      operations:
+      - name: listorders
+        method: GET
+        description: 'Squarespace API: listOrders'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  exposes:
+  - type: mcp
+    namespace: stripe-squarespace-mcp
+    description: MCP adapter for the stripe-squarespace integration.
+    tools:
+    - name: stripe_squarespace
+      description: Execute the stripe squarespace integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-squarespace-rest
+    port: 8080
+    description: REST adapter for the stripe-squarespace integration.
+    resources:
+    - path: /stripe-squarespace
+      name: stripe-squarespace
+      description: REST surface for the stripe-squarespace integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-squarespace integration.
+        call: stripe_squarespace
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-stigg.yaml
+++ b/integrations/stripe-stigg.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Enforce Stigg entitlements at Stripe checkout
+  description: Check Stigg entitlement before allowing a Stripe Checkout session to start (block over-quota purchases at point-of-sale).
+  tags:
+  - Stripe
+  - Integration
+  - Pricing / packaging
+  - stigg
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    STIGG_API_KEY: STIGG_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-checkout-sessions
+      path: /v1/checkout/sessions
+      operations:
+      - name: postcheckoutsession
+        method: POST
+        description: Create a Stripe Checkout session
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: stigg
+    baseUri: https://api.stigg.io
+    description: Stigg API operations consumed by this integration.
+    resources:
+    - name: api-v1-entitlements-customer-customerid
+      path: /api/v1/entitlements/customer/{customerId}
+      operations:
+      - name: getentitlements
+        method: GET
+        description: 'Stigg API: getEntitlements'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: customerId
+          in: path
+          type: string
+          description: Path parameter customerId.
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-stigg-mcp
+    description: MCP adapter for the stripe-stigg integration.
+    tools:
+    - name: stripe_stigg
+      description: Execute the stripe stigg integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-stigg-rest
+    port: 8080
+    description: REST adapter for the stripe-stigg integration.
+    resources:
+    - path: /stripe-stigg
+      name: stripe-stigg
+      description: REST surface for the stripe-stigg integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-stigg integration.
+        call: stripe_stigg
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-taxjar.yaml
+++ b/integrations/stripe-taxjar.yaml
@@ -1,0 +1,90 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: File Stripe sales through TaxJar
+  description: Sync Stripe Invoices to TaxJar as transactions for automated state filing.
+  tags:
+  - Stripe
+  - Integration
+  - Tax
+  - taxjar
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    TAXJAR_API_KEY: TAXJAR_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-invoices
+      path: /v1/invoices
+      operations:
+      - name: getinvoices
+        method: GET
+        description: List Stripe invoices
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: taxjar
+    baseUri: https://api.taxjar.com
+    description: TaxJar SmartCalcs API operations consumed by this integration.
+    resources:
+    - name: v2-transactions-orders
+      path: /v2/transactions/orders
+      operations:
+      - name: createordertransaction
+        method: POST
+        description: 'TaxJar SmartCalcs API: createOrderTransaction'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-taxjar-mcp
+    description: MCP adapter for the stripe-taxjar integration.
+    tools:
+    - name: stripe_taxjar
+      description: Execute the stripe taxjar integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-taxjar-rest
+    port: 8080
+    description: REST adapter for the stripe-taxjar integration.
+    resources:
+    - path: /stripe-taxjar
+      name: stripe-taxjar
+      description: REST surface for the stripe-taxjar integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-taxjar integration.
+        call: stripe_taxjar
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-twilio.yaml
+++ b/integrations/stripe-twilio.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: SMS Stripe payment receipts via Twilio
+  description: For each Stripe payment succeeded, send an SMS receipt via Twilio to the customer's phone number.
+  tags:
+  - Stripe
+  - Integration
+  - Notifications
+  - twilio
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    TWILIO_API_KEY: TWILIO_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: twilio
+    baseUri: https://api.twilio.com
+    description: Twilio Messaging API operations consumed by this integration.
+    resources:
+    - name: 2010-04-01-accounts-accountsid-messages-json
+      path: /2010-04-01/Accounts/{AccountSid}/Messages.json
+      operations:
+      - name: sendsms
+        method: POST
+        description: 'Twilio Messaging API: sendSms'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: AccountSid
+          in: path
+          type: string
+          description: Path parameter AccountSid.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-twilio-mcp
+    description: MCP adapter for the stripe-twilio integration.
+    tools:
+    - name: stripe_twilio
+      description: Execute the stripe twilio integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-twilio-rest
+    port: 8080
+    description: REST adapter for the stripe-twilio integration.
+    resources:
+    - path: /stripe-twilio
+      name: stripe-twilio
+      description: REST surface for the stripe-twilio integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-twilio integration.
+        call: stripe_twilio
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-vertex.yaml
+++ b/integrations/stripe-vertex.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Replace Stripe Tax with Vertex for enterprise tax determination
+  description: Use Vertex for tax determination, then attach the Vertex-computed line to the Stripe payment.
+  tags:
+  - Stripe
+  - Integration
+  - Tax
+  - vertex
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    VERTEX_API_KEY: VERTEX_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: postpaymentintent
+        method: POST
+        description: Create a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: vertex
+    baseUri: https://api.vertexsmb.com
+    description: Vertex Cloud API operations consumed by this integration.
+    resources:
+    - name: vertex-restapi-v1-sale
+      path: /vertex-restapi/v1/sale
+      operations:
+      - name: computesaletax
+        method: POST
+        description: 'Vertex Cloud API: computeSaleTax'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-vertex-mcp
+    description: MCP adapter for the stripe-vertex integration.
+    tools:
+    - name: stripe_vertex
+      description: Execute the stripe vertex integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-vertex-rest
+    port: 8080
+    description: REST adapter for the stripe-vertex integration.
+    resources:
+    - path: /stripe-vertex
+      name: stripe-vertex
+      description: REST surface for the stripe-vertex integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-vertex integration.
+        call: stripe_vertex
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-wave.yaml
+++ b/integrations/stripe-wave.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Mirror Stripe sales into Wave accounting
+  description: Sync Stripe payment events into Wave as income transactions in the right account category.
+  tags:
+  - Stripe
+  - Integration
+  - Accounting
+  - wave
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    WAVE_API_KEY: WAVE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-charges-id
+      path: /v1/charges/{id}
+      operations:
+      - name: getcharge
+        method: GET
+        description: Retrieve a Stripe charge
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: wave
+    baseUri: https://gql.waveapps.com
+    description: Wave Accounting GraphQL operations consumed by this integration.
+    resources:
+    - name: graphql-public
+      path: /graphql/public
+      operations:
+      - name: createmoneytransaction
+        method: POST
+        description: 'Wave Accounting GraphQL: createMoneyTransaction'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-wave-mcp
+    description: MCP adapter for the stripe-wave integration.
+    tools:
+    - name: stripe_wave
+      description: Execute the stripe wave integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-wave-rest
+    port: 8080
+    description: REST adapter for the stripe-wave integration.
+    resources:
+    - path: /stripe-wave
+      name: stripe-wave
+      description: REST surface for the stripe-wave integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-wave integration.
+        call: stripe_wave
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-woocommerce.yaml
+++ b/integrations/stripe-woocommerce.yaml
@@ -1,0 +1,90 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Replace WooCommerce Stripe plugin with declarative integration
+  description: Move WooCommerce-to-Stripe handoff from the WP plugin to a declarative integration capability.
+  tags:
+  - Stripe
+  - Integration
+  - E-commerce
+  - woocommerce
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    WOOCOMMERCE_API_KEY: WOOCOMMERCE_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: postpaymentintent
+        method: POST
+        description: Create a Stripe payment intent
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  - type: http
+    namespace: woocommerce
+    baseUri: https://yourstore.com
+    description: WooCommerce REST API operations consumed by this integration.
+    resources:
+    - name: wp-json-wc-v3-orders
+      path: /wp-json/wc/v3/orders
+      operations:
+      - name: listorders
+        method: GET
+        description: 'WooCommerce REST API: listOrders'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  exposes:
+  - type: mcp
+    namespace: stripe-woocommerce-mcp
+    description: MCP adapter for the stripe-woocommerce integration.
+    tools:
+    - name: stripe_woocommerce
+      description: Execute the stripe woocommerce integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-woocommerce-rest
+    port: 8080
+    description: REST adapter for the stripe-woocommerce integration.
+    resources:
+    - path: /stripe-woocommerce
+      name: stripe-woocommerce
+      description: REST surface for the stripe-woocommerce integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-woocommerce integration.
+        call: stripe_woocommerce
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-workato.yaml
+++ b/integrations/stripe-workato.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Forward Stripe event to Workato recipe
+  description: Forward a Stripe event into a Workato recipe via a declarative capability.
+  tags:
+  - Stripe
+  - Integration
+  - Workflow
+  - workato
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    WORKATO_API_KEY: WORKATO_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-events
+      path: /v1/events
+      operations:
+      - name: getevents
+        method: GET
+        description: List Stripe events
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: workato
+    baseUri: https://www.workato.com
+    description: Workato API operations consumed by this integration.
+    resources:
+    - name: webhooks-rest-token
+      path: /webhooks/rest/{token}
+      operations:
+      - name: invokerecipe
+        method: POST
+        description: 'Workato API: invokeRecipe'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: token
+          in: path
+          type: string
+          description: Path parameter token.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-workato-mcp
+    description: MCP adapter for the stripe-workato integration.
+    tools:
+    - name: stripe_workato
+      description: Execute the stripe workato integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-workato-rest
+    port: 8080
+    description: REST adapter for the stripe-workato integration.
+    resources:
+    - path: /stripe-workato
+      name: stripe-workato
+      description: REST surface for the stripe-workato integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-workato integration.
+        call: stripe_workato
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-workos.yaml
+++ b/integrations/stripe-workos.yaml
@@ -1,0 +1,95 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Provision WorkOS organizations from Stripe Enterprise subscriptions
+  description: For Enterprise-tier Stripe subscriptions, create the corresponding WorkOS Organization with SSO configured.
+  tags:
+  - Stripe
+  - Integration
+  - Identity / SSO
+  - workos
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    WORKOS_API_KEY: WORKOS_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-subscriptions-id
+      path: /v1/subscriptions/{id}
+      operations:
+      - name: getsubscription
+        method: GET
+        description: Retrieve a Stripe subscription
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+  - type: http
+    namespace: workos
+    baseUri: https://api.workos.com
+    description: WorkOS API operations consumed by this integration.
+    resources:
+    - name: organizations
+      path: /organizations
+      operations:
+      - name: createorganization
+        method: POST
+        description: 'WorkOS API: createOrganization'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-workos-mcp
+    description: MCP adapter for the stripe-workos integration.
+    tools:
+    - name: stripe_workos
+      description: Execute the stripe workos integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-workos-rest
+    port: 8080
+    description: REST adapter for the stripe-workos integration.
+    resources:
+    - path: /stripe-workos
+      name: stripe-workos
+      description: REST surface for the stripe-workos integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-workos integration.
+        call: stripe_workos
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-xero.yaml
+++ b/integrations/stripe-xero.yaml
@@ -1,0 +1,102 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Reconcile Stripe payouts in Xero bank transactions
+  description: Match Stripe payouts to Xero bank transactions and create per-transaction reconciliation entries.
+  tags:
+  - Stripe
+  - Integration
+  - Accounting
+  - xero
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    XERO_API_KEY: XERO_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payouts
+      path: /v1/payouts
+      operations:
+      - name: getpayouts
+        method: GET
+        description: List Stripe payouts
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+    - name: v1-balance-transactions
+      path: /v1/balance_transactions
+      operations:
+      - name: getbalancetransactions
+        method: GET
+        description: List Stripe balance transactions
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: xero
+    baseUri: https://api.xero.com
+    description: Xero API operations consumed by this integration.
+    resources:
+    - name: api-xro-2-0-banktransactions
+      path: /api.xro/2.0/BankTransactions
+      operations:
+      - name: createbanktransaction
+        method: PUT
+        description: 'Xero API: createBankTransaction'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-xero-mcp
+    description: MCP adapter for the stripe-xero integration.
+    tools:
+    - name: stripe_xero
+      description: Execute the stripe xero integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-xero-rest
+    port: 8080
+    description: REST adapter for the stripe-xero integration.
+    resources:
+    - path: /stripe-xero
+      name: stripe-xero
+      description: REST surface for the stripe-xero integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-xero integration.
+        call: stripe_xero
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-zapier.yaml
+++ b/integrations/stripe-zapier.yaml
@@ -1,0 +1,100 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Stripe trigger spec for Zapier (declarative)
+  description: Declare the Stripe events that trigger Zapier Zaps as a Naftiko capability — replaces the closed Zapier app config.
+  tags:
+  - Stripe
+  - Integration
+  - Workflow
+  - zapier
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    ZAPIER_API_KEY: ZAPIER_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-events
+      path: /v1/events
+      operations:
+      - name: getevents
+        method: GET
+        description: List Stripe events
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: zapier
+    baseUri: https://hooks.zapier.com
+    description: Zapier Webhooks operations consumed by this integration.
+    resources:
+    - name: hooks-catch-hook-id-token
+      path: /hooks/catch/{hook_id}/{token}
+      operations:
+      - name: invokehook
+        method: POST
+        description: 'Zapier Webhooks: invokeHook'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: hook_id
+          in: path
+          type: string
+          description: Path parameter hook_id.
+          required: true
+        - name: token
+          in: path
+          type: string
+          description: Path parameter token.
+          required: true
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-zapier-mcp
+    description: MCP adapter for the stripe-zapier integration.
+    tools:
+    - name: stripe_zapier
+      description: Execute the stripe zapier integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-zapier-rest
+    port: 8080
+    description: REST adapter for the stripe-zapier integration.
+    resources:
+    - path: /stripe-zapier
+      name: stripe-zapier
+      description: REST surface for the stripe-zapier integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-zapier integration.
+        call: stripe_zapier
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-zendesk.yaml
+++ b/integrations/stripe-zendesk.yaml
@@ -1,0 +1,107 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Attach Stripe customer history to Zendesk tickets
+  description: When a Zendesk ticket opens, fetch the requester's Stripe Customer + recent charges and render them in a Zendesk app.
+  tags:
+  - Stripe
+  - Integration
+  - Support
+  - zendesk
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    ZENDESK_API_KEY: ZENDESK_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-charges
+      path: /v1/charges
+      operations:
+      - name: getcharges
+        method: GET
+        description: List Stripe charges
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: zendesk
+    baseUri: https://yoursubdomain.zendesk.com
+    description: Zendesk API operations consumed by this integration.
+    resources:
+    - name: api-v2-tickets
+      path: /api/v2/tickets
+      operations:
+      - name: createticket
+        method: POST
+        description: 'Zendesk API: createTicket'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-zendesk-mcp
+    description: MCP adapter for the stripe-zendesk integration.
+    tools:
+    - name: stripe_zendesk
+      description: Execute the stripe zendesk integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-zendesk-rest
+    port: 8080
+    description: REST adapter for the stripe-zendesk integration.
+    resources:
+    - path: /stripe-zendesk
+      name: stripe-zendesk
+      description: REST surface for the stripe-zendesk integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-zendesk integration.
+        call: stripe_zendesk
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-zoho-crm.yaml
+++ b/integrations/stripe-zoho-crm.yaml
@@ -1,0 +1,107 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Sync Stripe customer billing into Zoho CRM accounts
+  description: Push Stripe Customer billing details into matching Zoho CRM Accounts with custom MRR field.
+  tags:
+  - Stripe
+  - Integration
+  - CRM
+  - zoho-crm
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    ZOHO_CRM_API_KEY: ZOHO_CRM_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-customers-id
+      path: /v1/customers/{id}
+      operations:
+      - name: getcustomer
+        method: GET
+        description: Retrieve a Stripe customer
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: id
+          in: path
+          type: string
+          description: Path parameter id.
+          required: true
+    - name: v1-invoices
+      path: /v1/invoices
+      operations:
+      - name: getinvoices
+        method: GET
+        description: List Stripe invoices
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: zoho-crm
+    baseUri: https://www.zohoapis.com
+    description: Zoho CRM REST API operations consumed by this integration.
+    resources:
+    - name: crm-v5-accounts
+      path: /crm/v5/Accounts
+      operations:
+      - name: upsertaccount
+        method: POST
+        description: 'Zoho CRM REST API: upsertAccount'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters:
+        - name: body
+          in: body
+          type: object
+          description: Request body (JSON).
+          required: true
+  exposes:
+  - type: mcp
+    namespace: stripe-zoho-crm-mcp
+    description: MCP adapter for the stripe-zoho-crm integration.
+    tools:
+    - name: stripe_zoho_crm
+      description: Execute the stripe zoho crm integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-zoho-crm-rest
+    port: 8080
+    description: REST adapter for the stripe-zoho-crm integration.
+    resources:
+    - path: /stripe-zoho-crm
+      name: stripe-zoho-crm
+      description: REST surface for the stripe-zoho-crm integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-zoho-crm integration.
+        call: stripe_zoho_crm
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/integrations/stripe-zuora.yaml
+++ b/integrations/stripe-zuora.yaml
@@ -1,0 +1,85 @@
+naftiko: 1.0.0-alpha2
+info:
+  label: Reconcile Zuora invoices against Stripe payments
+  description: For each Zuora invoice, find and link the corresponding Stripe PaymentIntent and record the reconciliation status.
+  tags:
+  - Stripe
+  - Integration
+  - Subscription billing
+  - zuora
+  created: '2026-05-20'
+  modified: '2026-05-20'
+binds:
+- namespace: env
+  keys:
+    STRIPE_API_KEY: STRIPE_API_KEY
+    ZUORA_API_KEY: ZUORA_API_KEY
+capability:
+  consumes:
+  - type: http
+    namespace: stripe
+    baseUri: https://api.stripe.com
+    description: Stripe API operations consumed by this integration.
+    resources:
+    - name: v1-payment-intents
+      path: /v1/payment_intents
+      operations:
+      - name: getpaymentintents
+        method: GET
+        description: List Stripe payment intents
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  - type: http
+    namespace: zuora
+    baseUri: https://rest.zuora.com
+    description: Zuora REST API operations consumed by this integration.
+    resources:
+    - name: v1-invoices
+      path: /v1/invoices
+      operations:
+      - name: listinvoices
+        method: GET
+        description: 'Zuora REST API: listInvoices'
+        outputRawFormat: json
+        outputParameters:
+        - name: result
+          type: object
+          value: $.
+        inputParameters: []
+  exposes:
+  - type: mcp
+    namespace: stripe-zuora-mcp
+    description: MCP adapter for the stripe-zuora integration.
+    tools:
+    - name: stripe_zuora
+      description: Execute the stripe zuora integration end-to-end.
+      inputSchema:
+        type: object
+        properties:
+          trigger_event:
+            type: object
+            description: The triggering event payload (Stripe event or partner event).
+        required:
+        - trigger_event
+  - type: rest
+    namespace: stripe-zuora-rest
+    port: 8080
+    description: REST adapter for the stripe-zuora integration.
+    resources:
+    - path: /stripe-zuora
+      name: stripe-zuora
+      description: REST surface for the stripe-zuora integration.
+      operations:
+      - method: POST
+        name: trigger
+        description: Trigger the stripe-zuora integration.
+        call: stripe_zuora
+        with:
+          trigger_event: rest.body
+        outputParameters:
+        - type: object
+          mapping: $.

--- a/scripts/generate-integrations.py
+++ b/scripts/generate-integrations.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Generate Naftiko v0.5 alpha2 capability YAMLs for each integration in
+integrations-source.yml. Writes to temp/stripe/integrations/<slug>.yaml.
+
+Each capability:
+  - consumes both Stripe (api.stripe.com) operations + partner API operations
+  - exposes a REST adapter + MCP adapter that surface the integration as
+    a single coherent tool
+"""
+import datetime, re, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "integrations-source.yml"
+OUT_DIR = ROOT / "integrations"
+
+
+def load_yaml(p):
+    import yaml
+    with open(p) as f: return yaml.safe_load(f)
+
+
+def dump_yaml(p, data):
+    import yaml
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w") as f:
+        yaml.dump(data, f, sort_keys=False, allow_unicode=True, default_flow_style=False,
+                  width=10000)
+
+
+def slugify(name):
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+# Map common Stripe op names → minimal HTTP shape. Each value is
+# (method, path, description, body_required).
+STRIPE_OPS = {
+    "getCustomers":       ("GET",  "/v1/customers",                       "List Stripe customers",                 False),
+    "getCustomer":        ("GET",  "/v1/customers/{id}",                  "Retrieve a Stripe customer",            False),
+    "postCustomer":       ("POST", "/v1/customers",                       "Create a Stripe customer",              True),
+    "getCharges":         ("GET",  "/v1/charges",                         "List Stripe charges",                   False),
+    "getCharge":          ("GET",  "/v1/charges/{id}",                    "Retrieve a Stripe charge",              False),
+    "getDispute":         ("GET",  "/v1/disputes/{id}",                   "Retrieve a Stripe dispute",             False),
+    "postDispute":        ("POST", "/v1/disputes/{id}",                   "Update a Stripe dispute",               True),
+    "getPaymentIntents":  ("GET",  "/v1/payment_intents",                 "List Stripe payment intents",           False),
+    "getPaymentIntent":   ("GET",  "/v1/payment_intents/{id}",            "Retrieve a Stripe payment intent",      False),
+    "postPaymentIntent":  ("POST", "/v1/payment_intents",                 "Create a Stripe payment intent",        True),
+    "postPaymentIntentCapture": ("POST", "/v1/payment_intents/{id}/capture", "Capture a Stripe payment intent",   True),
+    "getPaymentMethod":   ("GET",  "/v1/payment_methods/{id}",            "Retrieve a Stripe payment method",      False),
+    "getSubscriptions":   ("GET",  "/v1/subscriptions",                   "List Stripe subscriptions",             False),
+    "getSubscription":    ("GET",  "/v1/subscriptions/{id}",              "Retrieve a Stripe subscription",        False),
+    "postSubscription":   ("POST", "/v1/subscriptions",                   "Create a Stripe subscription",          True),
+    "postSubscriptionItemUsage": ("POST", "/v1/subscription_items/{id}/usage_records", "Report subscription metered usage", True),
+    "getInvoices":        ("GET",  "/v1/invoices",                        "List Stripe invoices",                  False),
+    "getInvoice":         ("GET",  "/v1/invoices/{id}",                   "Retrieve a Stripe invoice",             False),
+    "getCheckoutSession": ("GET",  "/v1/checkout/sessions/{id}",          "Retrieve a Stripe Checkout session",    False),
+    "getCheckoutSessions":("GET",  "/v1/checkout/sessions",               "List Stripe Checkout sessions",         False),
+    "postCheckoutSession":("POST", "/v1/checkout/sessions",               "Create a Stripe Checkout session",      True),
+    "getPayout":          ("GET",  "/v1/payouts/{id}",                    "Retrieve a Stripe payout",              False),
+    "getPayouts":         ("GET",  "/v1/payouts",                         "List Stripe payouts",                   False),
+    "getBalanceTransactions": ("GET", "/v1/balance_transactions",         "List Stripe balance transactions",      False),
+    "getEvents":          ("GET",  "/v1/events",                          "List Stripe events",                    False),
+}
+
+
+def build_resource(name, path, op_name, method, description, body_required=False):
+    op = {
+        "name": op_name,
+        "method": method,
+        "description": description,
+        "outputRawFormat": "json",
+        "outputParameters": [{"name": "result", "type": "object", "value": "$."}],
+        "inputParameters": [],
+    }
+    # path parameters
+    for m in re.finditer(r"\{([^}]+)\}", path):
+        op["inputParameters"].append({
+            "name": m.group(1), "in": "path", "type": "string",
+            "description": f"Path parameter {m.group(1)}.", "required": True,
+        })
+    # body if needed
+    if method in ("POST", "PUT", "PATCH") or body_required:
+        op["inputParameters"].append({
+            "name": "body", "in": "body", "type": "object",
+            "description": "Request body (JSON).", "required": body_required or method == "POST",
+        })
+    return {"name": name, "path": path, "operations": [op]}
+
+
+def build_stripe_consume(stripe_ops):
+    resources = []
+    for op_key in stripe_ops:
+        if op_key not in STRIPE_OPS:
+            print(f"  WARN: unknown Stripe op '{op_key}', skipping", file=sys.stderr)
+            continue
+        method, path, desc, body_req = STRIPE_OPS[op_key]
+        rname = re.sub(r"[^a-z0-9]+", "-", path.lower()).strip("-")[:60]
+        resources.append(build_resource(rname, path, op_key.lower(), method, desc, body_req))
+    return {
+        "type": "http", "namespace": "stripe",
+        "baseUri": "https://api.stripe.com",
+        "description": "Stripe API operations consumed by this integration.",
+        "resources": resources,
+    }
+
+
+def build_partner_consume(partner_slug, partner_baseUri, partner_api, partner_ops):
+    resources = []
+    for o in partner_ops:
+        method = o["method"]
+        path = o["path"]
+        name = o["name"]
+        rname = re.sub(r"[^a-z0-9]+", "-", path.lower()).strip("-")[:60] or partner_slug
+        resources.append(build_resource(rname, path, name.lower(),
+                                        method, f"{partner_api}: {name}",
+                                        body_required=(method in ("POST","PUT","PATCH"))))
+    return {
+        "type": "http", "namespace": partner_slug,
+        "baseUri": partner_baseUri,
+        "description": f"{partner_api} operations consumed by this integration.",
+        "resources": resources,
+    }
+
+
+def build_exposes(integration_slug, stripe_ops, partner_ops, partner_slug):
+    """Expose ONE MCP tool that runs the integration end-to-end, plus a REST
+    surface mirroring each consumed operation."""
+    mcp_tools = []
+    # Synthesize the lead tool from the integration name
+    mcp_tools.append({
+        "name": integration_slug.replace("-", "_"),
+        "description": f"Execute the {integration_slug.replace('-', ' ')} integration end-to-end.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "trigger_event": {"type": "object", "description": "The triggering event payload (Stripe event or partner event)."}
+            },
+            "required": ["trigger_event"],
+        },
+    })
+    return [
+        {
+            "type": "mcp", "namespace": f"{integration_slug}-mcp",
+            "description": f"MCP adapter for the {integration_slug} integration.",
+            "tools": mcp_tools,
+        },
+        {
+            "type": "rest", "namespace": f"{integration_slug}-rest",
+            "port": 8080,
+            "description": f"REST adapter for the {integration_slug} integration.",
+            "resources": [{
+                "path": f"/{integration_slug}",
+                "name": integration_slug,
+                "description": f"REST surface for the {integration_slug} integration.",
+                "operations": [{
+                    "method": "POST",
+                    "name": "trigger",
+                    "description": f"Trigger the {integration_slug} integration.",
+                    "call": f"{integration_slug.replace('-', '_')}",
+                    "with": {"trigger_event": "rest.body"},
+                    "outputParameters": [{"type": "object", "mapping": "$."}],
+                }],
+            }],
+        },
+    ]
+
+
+def build_capability(entry):
+    integration_slug = f"stripe-{entry['partner']}"
+    today = datetime.date.today().isoformat()
+
+    stripe_consume = build_stripe_consume(entry["stripe_ops"])
+    partner_consume = build_partner_consume(
+        entry["partner"], entry["partner_baseUri"],
+        entry["partner_api"], entry["partner_ops"],
+    )
+    exposes = build_exposes(integration_slug, entry["stripe_ops"], entry["partner_ops"], entry["partner"])
+
+    cap = {
+        "naftiko": "1.0.0-alpha2",
+        "info": {
+            "label": entry["name"],
+            "description": entry["use_case"],
+            "tags": ["Stripe", "Integration", entry["category"], entry["partner"]],
+            "created": today,
+            "modified": today,
+        },
+        "binds": [
+            {"namespace": "env", "keys": {
+                "STRIPE_API_KEY": "STRIPE_API_KEY",
+                f"{entry['partner'].upper().replace('-','_')}_API_KEY":
+                    f"{entry['partner'].upper().replace('-','_')}_API_KEY",
+            }},
+        ],
+        "capability": {
+            "consumes": [stripe_consume, partner_consume],
+            "exposes": exposes,
+        },
+    }
+    return integration_slug, cap
+
+
+def main():
+    if not SOURCE.exists():
+        sys.exit(f"Missing {SOURCE}")
+    entries = load_yaml(SOURCE) or []
+    print(f"Loaded {len(entries)} integration entries")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    n = 0
+    index = []
+    for entry in entries:
+        slug, cap = build_capability(entry)
+        out = OUT_DIR / f"{slug}.yaml"
+        dump_yaml(out, cap)
+        index.append({
+            "slug": slug, "label": entry["name"], "partner": entry["partner"],
+            "category": entry["category"], "use_case": entry["use_case"],
+        })
+        n += 1
+    # Write integrations index
+    dump_yaml(OUT_DIR / "_index.yml", index)
+    print(f"Wrote {n} integration capability YAMLs → {OUT_DIR}")
+    print(f"Wrote index → {OUT_DIR / '_index.yml'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new top-level **`/integrations/`** folder with **54 Naftiko v0.5 alpha2 capability YAMLs** — one per Stripe + partner integration.

Each file is a self-contained declarative integration:
- **consumes** the relevant Stripe operations
- **consumes** the partner's matching API operations
- **exposes** a unified MCP tool + REST adapter
- **binds** the env-var API keys both sides need

## Categories covered (12)

| Category | Count |
|---|---|
| CRM / Sales | 6 (Salesforce, HubSpot, Pipedrive, Close, Zoho, Outreach) |
| Email marketing | 6 (Mailchimp, Klaviyo, SendGrid, Customer.io, Iterable, Braze) |
| Subscription billing | 5 (Chargebee, Recurly, Zuora, Maxio, Stigg) |
| Accounting / ERP | 6 (QuickBooks, Xero, NetSuite, Sage Intacct, FreshBooks, Wave) |
| Tax | 4 (Avalara, TaxJar, Vertex, Anrok) |
| Identity / Auth | 4 (Auth0, Okta, WorkOS, Clerk) |
| Analytics / Data | 5 (Segment, Mixpanel, Amplitude, Snowflake, Looker) |
| Support | 4 (Zendesk, Intercom, Front, Gorgias) |
| E-commerce | 4 (Shopify, BigCommerce, WooCommerce, Squarespace) |
| Workflow | 4 (Zapier, Make, n8n, Workato) |
| Notifications | 3 (Twilio, Slack, MessageBird) |
| Fraud / risk | 3 (Sift, Riskified, Chargehound) |

## Files

- `integrations-source.yml` — curated input list
- `integrations/_index.yml` — auto-generated directory index
- `integrations/stripe-*.yaml` — 54 individual integration capability files
- `scripts/generate-integrations.py` — regenerates the folder from the source

## Why

This is the artifact behind the [Naftiko blog post on declarative integrations](https://naftiko.io/blog/integrations-pages-are-a-2010s-artifact). The thesis: static integrations marketing pages (a logo grid linking to one-off bespoke docs) don't compose with an agent's toolchain. A folder of declarative integration capabilities is the next-generation replacement — the agent reads the YAML directly, the marketing page renders from the same source.

## Test plan

- [x] All 54 YAMLs parse cleanly with `yaml.safe_load`
- [x] All files conform to the `naftiko: 1.0.0-alpha2` shape used by the existing 322 capabilities in `capabilities/`
- [ ] `providers.apis.io/providers/stripe/integrations` to render the folder once apis.io picks up the new path

## Related

- Blog post: `naftiko/website` → `_posts/2026-05-20-integrations-pages-are-a-2010s-artifact.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)